### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4413,7 +4413,7 @@ dependencies = [
 
 [[package]]
 name = "harvest-static-yield"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "clap",
@@ -12807,7 +12807,7 @@ dependencies = [
 
 [[package]]
 name = "templar-accumulator"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "clap",
@@ -12826,7 +12826,7 @@ dependencies = [
 
 [[package]]
 name = "templar-common"
-version = "1.5.0"
+version = "2.0.0"
 dependencies = [
  "borsh 1.6.1",
  "clap",
@@ -12901,7 +12901,7 @@ dependencies = [
 
 [[package]]
 name = "templar-funding-bridge"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12971,7 +12971,7 @@ dependencies = [
 
 [[package]]
 name = "templar-gateway-artifacts-dispatch"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "near-account-id",
@@ -12989,7 +12989,7 @@ dependencies = [
 
 [[package]]
 name = "templar-gateway-artifacts-spec"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "near-account-id",
  "schemars 0.8.22",
@@ -13013,7 +13013,7 @@ dependencies = [
 
 [[package]]
 name = "templar-gateway-client"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "clap",
  "near-api",
@@ -13031,7 +13031,7 @@ dependencies = [
 
 [[package]]
 name = "templar-gateway-core"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "actix",
  "anyhow",
@@ -13078,7 +13078,7 @@ dependencies = [
 
 [[package]]
 name = "templar-gateway-methods-dispatch"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "borsh 1.6.1",
@@ -13102,7 +13102,7 @@ dependencies = [
 
 [[package]]
 name = "templar-gateway-methods-spec"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "near-account-id",
  "schemars 0.8.22",
@@ -13120,7 +13120,7 @@ dependencies = [
 
 [[package]]
 name = "templar-gateway-oracle-updates-dispatch"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -13158,7 +13158,7 @@ dependencies = [
 
 [[package]]
 name = "templar-gateway-oracle-updates-spec"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "hex",
  "near-account-id",
@@ -13173,7 +13173,7 @@ dependencies = [
 
 [[package]]
 name = "templar-gateway-runtime"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "actix",
  "async-trait",
@@ -13187,7 +13187,7 @@ dependencies = [
 
 [[package]]
 name = "templar-gateway-service"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "actix",
  "anyhow",
@@ -13237,7 +13237,7 @@ dependencies = [
 
 [[package]]
 name = "templar-gateway-store"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "async-trait",
  "borsh 1.6.1",
@@ -13292,7 +13292,7 @@ dependencies = [
 
 [[package]]
 name = "templar-gateway-types"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "base64 0.22.1",
  "borsh 1.6.1",
@@ -13315,7 +13315,7 @@ dependencies = [
 
 [[package]]
 name = "templar-liquidator"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -13349,7 +13349,7 @@ dependencies = [
 
 [[package]]
 name = "templar-lst-oracle-contract"
-version = "1.2.3"
+version = "1.2.4"
 dependencies = [
  "anyhow",
  "getrandom 0.2.17",
@@ -13369,7 +13369,7 @@ dependencies = [
 
 [[package]]
 name = "templar-manager"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -13410,7 +13410,7 @@ dependencies = [
 
 [[package]]
 name = "templar-market-contract"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "anyhow",
  "getrandom 0.2.17",
@@ -13434,7 +13434,7 @@ dependencies = [
 
 [[package]]
 name = "templar-market-monitor"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -13458,7 +13458,7 @@ dependencies = [
 
 [[package]]
 name = "templar-primitives"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "borsh 1.6.1",
  "near-sdk",
@@ -13475,7 +13475,7 @@ dependencies = [
 
 [[package]]
 name = "templar-proxy-oracle-governance-kernel"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "borsh 1.6.1",
  "rstest",
@@ -13487,7 +13487,7 @@ dependencies = [
 
 [[package]]
 name = "templar-proxy-oracle-kernel"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "borsh 1.6.1",
  "getrandom 0.2.17",
@@ -13505,7 +13505,7 @@ dependencies = [
 
 [[package]]
 name = "templar-proxy-oracle-near-common"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "near-primitives",
  "near-sdk",
@@ -13517,7 +13517,7 @@ dependencies = [
 
 [[package]]
 name = "templar-proxy-oracle-near-contract"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -13541,7 +13541,7 @@ dependencies = [
 
 [[package]]
 name = "templar-proxy-oracle-near-governance-common"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "clap",
  "near-sdk",
@@ -13555,7 +13555,7 @@ dependencies = [
 
 [[package]]
 name = "templar-proxy-oracle-near-governance-contract"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -13577,7 +13577,7 @@ dependencies = [
 
 [[package]]
 name = "templar-proxy-oracle-soroban-common"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "rstest",
  "soroban-sdk",
@@ -13586,7 +13586,7 @@ dependencies = [
 
 [[package]]
 name = "templar-proxy-oracle-soroban-contract"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "postcard",
  "soroban-sdk",
@@ -13599,7 +13599,7 @@ dependencies = [
 
 [[package]]
 name = "templar-proxy-oracle-soroban-governance-common"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "soroban-sdk",
  "templar-primitives",
@@ -13609,7 +13609,7 @@ dependencies = [
 
 [[package]]
 name = "templar-proxy-oracle-soroban-governance-contract"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "soroban-sdk",
  "stellar-access",
@@ -13638,7 +13638,7 @@ dependencies = [
 
 [[package]]
 name = "templar-proxy-oracle-soroban-sep40-adapter-contract"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "soroban-sdk",
  "stellar-access",
@@ -13650,7 +13650,7 @@ dependencies = [
 
 [[package]]
 name = "templar-pyth-lazer-adapter-contract"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "byteorder",
  "ed25519-dalek",
@@ -13668,7 +13668,7 @@ dependencies = [
 
 [[package]]
 name = "templar-pyth-lazer-verifier"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "base64 0.22.1",
  "byteorder",
@@ -13681,7 +13681,7 @@ dependencies = [
 
 [[package]]
 name = "templar-redstone-adapter-contract"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "getrandom 0.2.17",
  "hex-literal",
@@ -13695,7 +13695,7 @@ dependencies = [
 
 [[package]]
 name = "templar-redstone-bridge"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "hex",
  "serde",
@@ -13708,7 +13708,7 @@ dependencies = [
 
 [[package]]
 name = "templar-registry-contract"
-version = "1.2.4"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "getrandom 0.2.17",
@@ -13727,7 +13727,7 @@ dependencies = [
 
 [[package]]
 name = "templar-relayer"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -13873,7 +13873,7 @@ dependencies = [
 
 [[package]]
 name = "templar-tools-common"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "cargo_metadata 0.23.1",
@@ -13883,7 +13883,7 @@ dependencies = [
 
 [[package]]
 name = "templar-universal-account"
-version = "1.2.3"
+version = "1.2.4"
 dependencies = [
  "alloy",
  "alloy-primitives",
@@ -13907,7 +13907,7 @@ dependencies = [
 
 [[package]]
 name = "templar-universal-account-contract"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -13927,7 +13927,7 @@ dependencies = [
 
 [[package]]
 name = "templar-vault-client"
-version = "1.2.3"
+version = "1.2.4"
 dependencies = [
  "anyhow",
  "futures",
@@ -13955,7 +13955,7 @@ dependencies = [
 
 [[package]]
 name = "templar-vault-contract"
-version = "1.2.3"
+version = "1.2.4"
 dependencies = [
  "anyhow",
  "borsh 1.6.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -138,33 +138,33 @@ solana-sdk = "3.0.0"
 sputnikdao2 = { git = "https://github.com/near-daos/sputnik-dao-contract", rev = "5434a59dec23ee0c49df8c8c4350c208a7e75b0b" }
 stellar-strkey = { version = "0.0.16", default-features = false }
 strum = { version = "0.27", features = ["derive"] }
-templar-common = { path = "./common", version = "1.5.0" }
+templar-common = { path = "./common", version = "2.0.0" }
 templar-contract-artifacts = { path = "./contract/artifacts" }
 templar-gateway-artifacts-dispatch = { path = "./gateway/artifacts-dispatch" }
 templar-gateway-artifacts-spec = { path = "./gateway/artifacts-spec" }
-templar-gateway-client = { path = "./gateway/client", version = "0.2.1" }
-templar-gateway-core = { path = "./gateway/core", version = "0.3.0" }
+templar-gateway-client = { path = "./gateway/client", version = "0.2.2" }
+templar-gateway-core = { path = "./gateway/core", version = "0.4.0" }
 templar-gateway-macros = { path = "./gateway/macros", version = "0.1.1" }
-templar-gateway-methods-dispatch = { path = "./gateway/methods-dispatch", version = "0.3.0" }
-templar-gateway-methods-spec = { path = "./gateway/methods-spec", version = "0.3.0" }
+templar-gateway-methods-dispatch = { path = "./gateway/methods-dispatch", version = "0.4.0" }
+templar-gateway-methods-spec = { path = "./gateway/methods-spec", version = "0.4.0" }
 templar-gateway-oracle-updates-dispatch = { path = "./gateway/oracle-updates-dispatch" }
 templar-gateway-oracle-updates-spec = { path = "./gateway/oracle-updates-spec" }
 templar-gateway-runtime = { path = "./gateway/runtime" }
-templar-gateway-store = { path = "./gateway/store", version = "0.2.0" }
+templar-gateway-store = { path = "./gateway/store", version = "0.2.1" }
 templar-gateway-testing = { path = "./gateway/testing" }
-templar-gateway-types = { path = "./gateway/types", version = "0.2.0" }
-templar-primitives = { path = "./primitives", version = "0.1.1" }
-templar-proxy-oracle-governance-kernel = { path = "./contract/proxy-oracle/governance-kernel", version = "0.2.0" }
-templar-proxy-oracle-kernel = { path = "./contract/proxy-oracle/kernel", version = "0.1.1" }
-templar-proxy-oracle-near-common = { path = "./contract/proxy-oracle/near/common", version = "0.1.2" }
+templar-gateway-types = { path = "./gateway/types", version = "0.3.0" }
+templar-primitives = { path = "./primitives", version = "0.1.2" }
+templar-proxy-oracle-governance-kernel = { path = "./contract/proxy-oracle/governance-kernel", version = "0.2.1" }
+templar-proxy-oracle-kernel = { path = "./contract/proxy-oracle/kernel", version = "0.1.2" }
+templar-proxy-oracle-near-common = { path = "./contract/proxy-oracle/near/common", version = "0.1.3" }
 templar-proxy-oracle-near-contract = { path = "./contract/proxy-oracle/near/contract" }
-templar-proxy-oracle-near-governance-common = { path = "./contract/proxy-oracle/near/governance-common", version = "0.2.1" }
+templar-proxy-oracle-near-governance-common = { path = "./contract/proxy-oracle/near/governance-common", version = "0.2.2" }
 templar-proxy-oracle-near-governance-contract = { path = "./contract/proxy-oracle/near/governance-contract" }
 templar-pyth-lazer-adapter-contract = { path = "./contract/pyth-lazer/contract" }
 templar-pyth-lazer-verifier = { path = "./contract/pyth-lazer/verifier" }
 templar-redstone-bridge = { path = "./service/redstone-bridge" }
 templar-tools-common = { path = "./tools/tools-common" }
-templar-universal-account = { path = "./universal-account", version = "1.2.3" }
+templar-universal-account = { path = "./universal-account", version = "1.2.4" }
 templar-vault-contract = { path = "./contract/vault/near" }
 templar-vault-kernel = { path = "./contract/vault/kernel", version = "1.0.1", features = [
     "near",

--- a/client/vault/Cargo.toml
+++ b/client/vault/Cargo.toml
@@ -6,7 +6,7 @@ edition.workspace = true
 rust-version.workspace = true
 # Explicit, not inherited: this crate is released on its own tag, and sharing
 # `[workspace.package].version` would drag every other inheritor along with it.
-version = "1.2.3"
+version = "1.2.4"
 
 [lib]
 crate-type = ["cdylib"]

--- a/common/CHANGELOG.md
+++ b/common/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0](https://github.com/Templar-Protocol/contracts/compare/templar-common-v1.5.0...templar-common-v2.0.0) - 2026-08-24
+
+### Added
+
+- *(common)* registry view types for sound target and version checks (ENG-559, ENG-560) ([#587](https://github.com/Templar-Protocol/contracts/pull/587))
+- *(gateway)* [**breaking**] factor out the shared deploy-from-registry op structure (ENG-466) ([#594](https://github.com/Templar-Protocol/contracts/pull/594))
+- *(registry)* [**breaking**] register an existing global contract by code hash (ENG-631) ([#596](https://github.com/Templar-Protocol/contracts/pull/596))
+
+### Fixed
+
+- *(proxy-oracle)* remediate Halborn findings ([#595](https://github.com/Templar-Protocol/contracts/pull/595))
+
 ## [1.5.0](https://github.com/Templar-Protocol/contracts/compare/templar-common-v1.4.1...templar-common-v1.5.0) - 2026-08-04
 
 ### Added

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -4,7 +4,7 @@ rust-version.workspace = true
 license.workspace = true
 name = "templar-common"
 repository.workspace = true
-version = "1.5.0"
+version = "2.0.0"
 description = "Shared contract types, events, assets, and math for Templar Protocol"
 
 [dependencies]

--- a/contract/market/CHANGELOG.md
+++ b/contract/market/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.1](https://github.com/Templar-Protocol/contracts/compare/templar-market-contract-v1.5.0...templar-market-contract-v1.5.1) - 2026-08-24
+
+### Fixed
+
+- *(proxy-oracle)* remediate Halborn findings ([#595](https://github.com/Templar-Protocol/contracts/pull/595))
+
 ## [1.5.0](https://github.com/Templar-Protocol/contracts/compare/templar-market-contract-v1.4.2...templar-market-contract-v1.5.0) - 2026-08-04
 
 ### Added

--- a/contract/market/Cargo.toml
+++ b/contract/market/Cargo.toml
@@ -4,7 +4,7 @@ rust-version.workspace = true
 license.workspace = true
 name = "templar-market-contract"
 repository.workspace = true
-version = "1.5.0"
+version = "1.5.1"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/contract/proxy-oracle/governance-kernel/CHANGELOG.md
+++ b/contract/proxy-oracle/governance-kernel/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/Templar-Protocol/contracts/compare/templar-proxy-oracle-governance-kernel-v0.2.0...templar-proxy-oracle-governance-kernel-v0.2.1) - 2026-08-24
+
+### Fixed
+
+- *(proxy-oracle)* remediate Halborn findings ([#595](https://github.com/Templar-Protocol/contracts/pull/595))
+
 ## [0.2.0](https://github.com/Templar-Protocol/contracts/compare/templar-proxy-oracle-governance-kernel-v0.1.1...templar-proxy-oracle-governance-kernel-v0.2.0) - 2026-08-03
 
 ### Added

--- a/contract/proxy-oracle/governance-kernel/Cargo.toml
+++ b/contract/proxy-oracle/governance-kernel/Cargo.toml
@@ -4,14 +4,14 @@ license.workspace = true
 repository.workspace = true
 edition.workspace = true
 rust-version.workspace = true
-version = "0.2.0"
+version = "0.2.1"
 description = "Storage-agnostic governance kernel for Templar proxy oracles"
 
 [dependencies]
 borsh = { version = "1.5", default-features = false, features = ["derive", "unstable__schema"], optional = true }
 schemars = { version = "0.8", default-features = false, features = ["derive"], optional = true }
 serde = { version = "1", default-features = false, features = ["alloc", "derive"], optional = true }
-templar-primitives = { path = "../../../primitives", version = "0.1.1", default-features = false, features = [] }
+templar-primitives = { path = "../../../primitives", version = "0.1.2", default-features = false, features = [] }
 
 [dev-dependencies]
 rstest.workspace = true

--- a/contract/proxy-oracle/kernel/CHANGELOG.md
+++ b/contract/proxy-oracle/kernel/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/Templar-Protocol/contracts/compare/templar-proxy-oracle-kernel-v0.1.1...templar-proxy-oracle-kernel-v0.1.2) - 2026-08-24
+
+### Fixed
+
+- *(proxy-oracle)* remediate Halborn findings ([#595](https://github.com/Templar-Protocol/contracts/pull/595))
+
 ## [0.1.1](https://github.com/Templar-Protocol/contracts/compare/templar-proxy-oracle-kernel-v0.1.0...templar-proxy-oracle-kernel-v0.1.1) - 2026-08-03
 
 ### Added

--- a/contract/proxy-oracle/kernel/Cargo.toml
+++ b/contract/proxy-oracle/kernel/Cargo.toml
@@ -4,7 +4,7 @@ license.workspace = true
 repository.workspace = true
 edition.workspace = true
 rust-version.workspace = true
-version = "0.1.1"
+version = "0.1.2"
 description = "Storage-agnostic price-aggregation kernel for Templar proxy oracles"
 
 [dependencies]
@@ -14,7 +14,7 @@ hex = { version =  "0.4", default-features = false, features = ["alloc"], option
 primitive-types = { version = "0.14", default-features = false, features = [] }
 serde = { version = "1", default-features = false, features = ["alloc", "derive"], optional = true }
 schemars = { version = "0.8", default-features = false, features = ["derive"], optional = true }
-templar-primitives = { path = "../../../primitives", version = "0.1.1", default-features = false, features = [] }
+templar-primitives = { path = "../../../primitives", version = "0.1.2", default-features = false, features = [] }
 
 [dev-dependencies]
 hex-literal.workspace = true

--- a/contract/proxy-oracle/near/common/CHANGELOG.md
+++ b/contract/proxy-oracle/near/common/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/Templar-Protocol/contracts/compare/templar-proxy-oracle-near-common-v0.1.2...templar-proxy-oracle-near-common-v0.1.3) - 2026-08-24
+
+### Fixed
+
+- *(proxy-oracle)* remediate Halborn findings ([#595](https://github.com/Templar-Protocol/contracts/pull/595))
+
 ## [0.1.1](https://github.com/Templar-Protocol/contracts/compare/templar-proxy-oracle-near-common-v0.1.0...templar-proxy-oracle-near-common-v0.1.1) - 2026-08-03
 
 ### Added

--- a/contract/proxy-oracle/near/common/Cargo.toml
+++ b/contract/proxy-oracle/near/common/Cargo.toml
@@ -4,7 +4,7 @@ license.workspace = true
 repository.workspace = true
 edition.workspace = true
 rust-version.workspace = true
-version = "0.1.2"
+version = "0.1.3"
 description = "Shared NEAR-facing types for the Templar proxy oracle contract"
 
 [dependencies]

--- a/contract/proxy-oracle/near/contract/CHANGELOG.md
+++ b/contract/proxy-oracle/near/contract/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.3](https://github.com/Templar-Protocol/contracts/compare/templar-proxy-oracle-near-contract-v0.4.2...templar-proxy-oracle-near-contract-v0.4.3) - 2026-08-24
+
+### Fixed
+
+- *(proxy-oracle)* remediate Halborn findings ([#595](https://github.com/Templar-Protocol/contracts/pull/595))
+
 ## [0.4.0](https://github.com/Templar-Protocol/contracts/compare/templar-proxy-oracle-near-contract-v0.3.0...templar-proxy-oracle-near-contract-v0.4.0) - 2026-08-03
 
 ### Added

--- a/contract/proxy-oracle/near/contract/Cargo.toml
+++ b/contract/proxy-oracle/near/contract/Cargo.toml
@@ -4,7 +4,7 @@ rust-version.workspace = true
 license.workspace = true
 name = "templar-proxy-oracle-near-contract"
 repository.workspace = true
-version = "0.4.2"
+version = "0.4.3"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/contract/proxy-oracle/near/governance-common/CHANGELOG.md
+++ b/contract/proxy-oracle/near/governance-common/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2](https://github.com/Templar-Protocol/contracts/compare/templar-proxy-oracle-near-governance-common-v0.2.1...templar-proxy-oracle-near-governance-common-v0.2.2) - 2026-08-24
+
+### Fixed
+
+- *(proxy-oracle)* remediate Halborn findings ([#595](https://github.com/Templar-Protocol/contracts/pull/595))
+
 ## [0.2.0](https://github.com/Templar-Protocol/contracts/compare/templar-proxy-oracle-near-governance-common-v0.1.1...templar-proxy-oracle-near-governance-common-v0.2.0) - 2026-08-03
 
 ### Added

--- a/contract/proxy-oracle/near/governance-common/Cargo.toml
+++ b/contract/proxy-oracle/near/governance-common/Cargo.toml
@@ -4,7 +4,7 @@ license.workspace = true
 repository.workspace = true
 edition.workspace = true
 rust-version.workspace = true
-version = "0.2.1"
+version = "0.2.2"
 description = "Shared NEAR-facing types for the Templar proxy oracle governance contract"
 
 [dependencies]

--- a/contract/proxy-oracle/near/governance-contract/CHANGELOG.md
+++ b/contract/proxy-oracle/near/governance-contract/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.2](https://github.com/Templar-Protocol/contracts/compare/templar-proxy-oracle-near-governance-contract-v0.3.1...templar-proxy-oracle-near-governance-contract-v0.3.2) - 2026-08-24
+
+### Fixed
+
+- *(proxy-oracle)* remediate Halborn findings ([#595](https://github.com/Templar-Protocol/contracts/pull/595))
+
 ## [0.3.0](https://github.com/Templar-Protocol/contracts/compare/templar-proxy-oracle-near-governance-contract-v0.2.0...templar-proxy-oracle-near-governance-contract-v0.3.0) - 2026-08-03
 
 ### Added

--- a/contract/proxy-oracle/near/governance-contract/Cargo.toml
+++ b/contract/proxy-oracle/near/governance-contract/Cargo.toml
@@ -4,7 +4,7 @@ rust-version.workspace = true
 license.workspace = true
 name = "templar-proxy-oracle-near-governance-contract"
 repository.workspace = true
-version = "0.3.1"
+version = "0.3.2"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/contract/proxy-oracle/near/lst-contract/Cargo.toml
+++ b/contract/proxy-oracle/near/lst-contract/Cargo.toml
@@ -4,7 +4,7 @@ rust-version.workspace = true
 license.workspace = true
 name = "templar-lst-oracle-contract"
 repository.workspace = true
-version = "1.2.3"
+version = "1.2.4"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/contract/proxy-oracle/soroban/common/CHANGELOG.md
+++ b/contract/proxy-oracle/soroban/common/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/Templar-Protocol/contracts/compare/templar-proxy-oracle-soroban-common-v0.1.1...templar-proxy-oracle-soroban-common-v0.1.2) - 2026-08-24
+
+### Fixed
+
+- *(proxy-oracle)* remediate Halborn findings ([#595](https://github.com/Templar-Protocol/contracts/pull/595))
+
 ## [0.1.1](https://github.com/Templar-Protocol/contracts/compare/templar-proxy-oracle-soroban-common-v0.1.0...templar-proxy-oracle-soroban-common-v0.1.1) - 2026-08-03
 
 ### Added

--- a/contract/proxy-oracle/soroban/common/Cargo.toml
+++ b/contract/proxy-oracle/soroban/common/Cargo.toml
@@ -4,7 +4,7 @@ license.workspace = true
 repository.workspace = true
 edition.workspace = true
 rust-version.workspace = true
-version = "0.1.1"
+version = "0.1.2"
 
 [lib]
 crate-type = ["rlib"]

--- a/contract/proxy-oracle/soroban/contract/CHANGELOG.md
+++ b/contract/proxy-oracle/soroban/contract/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/Templar-Protocol/contracts/compare/templar-proxy-oracle-soroban-contract-v0.1.1...templar-proxy-oracle-soroban-contract-v0.1.2) - 2026-08-24
+
+### Fixed
+
+- *(proxy-oracle)* remediate Halborn findings ([#595](https://github.com/Templar-Protocol/contracts/pull/595))
+
 ## [0.1.1](https://github.com/Templar-Protocol/contracts/compare/templar-proxy-oracle-soroban-contract-v0.1.0...templar-proxy-oracle-soroban-contract-v0.1.1) - 2026-08-03
 
 ### Added

--- a/contract/proxy-oracle/soroban/contract/Cargo.toml
+++ b/contract/proxy-oracle/soroban/contract/Cargo.toml
@@ -4,7 +4,7 @@ license.workspace = true
 repository.workspace = true
 edition.workspace = true
 rust-version.workspace = true
-version = "0.1.1"
+version = "0.1.2"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/contract/proxy-oracle/soroban/governance-common/CHANGELOG.md
+++ b/contract/proxy-oracle/soroban/governance-common/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/Templar-Protocol/contracts/compare/templar-proxy-oracle-soroban-governance-common-v0.2.0...templar-proxy-oracle-soroban-governance-common-v0.2.1) - 2026-08-24
+
+### Fixed
+
+- *(proxy-oracle)* remediate Halborn findings ([#595](https://github.com/Templar-Protocol/contracts/pull/595))
+
 ## [0.2.0](https://github.com/Templar-Protocol/contracts/compare/templar-proxy-oracle-soroban-governance-common-v0.1.1...templar-proxy-oracle-soroban-governance-common-v0.2.0) - 2026-08-03
 
 ### Added

--- a/contract/proxy-oracle/soroban/governance-common/Cargo.toml
+++ b/contract/proxy-oracle/soroban/governance-common/Cargo.toml
@@ -4,7 +4,7 @@ license.workspace = true
 repository.workspace = true
 edition.workspace = true
 rust-version.workspace = true
-version = "0.2.0"
+version = "0.2.1"
 
 [lib]
 crate-type = ["rlib"]

--- a/contract/proxy-oracle/soroban/governance-contract/CHANGELOG.md
+++ b/contract/proxy-oracle/soroban/governance-contract/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/Templar-Protocol/contracts/compare/templar-proxy-oracle-soroban-governance-contract-v0.1.2...templar-proxy-oracle-soroban-governance-contract-v0.1.3) - 2026-08-24
+
+### Fixed
+
+- *(proxy-oracle)* remediate Halborn findings ([#595](https://github.com/Templar-Protocol/contracts/pull/595))
+
 ## [0.1.1](https://github.com/Templar-Protocol/contracts/compare/templar-proxy-oracle-soroban-governance-contract-v0.1.0...templar-proxy-oracle-soroban-governance-contract-v0.1.1) - 2026-08-03
 
 ### Added

--- a/contract/proxy-oracle/soroban/governance-contract/Cargo.toml
+++ b/contract/proxy-oracle/soroban/governance-contract/Cargo.toml
@@ -4,7 +4,7 @@ license.workspace = true
 repository.workspace = true
 edition.workspace = true
 rust-version.workspace = true
-version = "0.1.2"
+version = "0.1.3"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/contract/proxy-oracle/soroban/sep40-adapter-contract/CHANGELOG.md
+++ b/contract/proxy-oracle/soroban/sep40-adapter-contract/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/Templar-Protocol/contracts/compare/templar-proxy-oracle-soroban-sep40-adapter-contract-v0.1.1...templar-proxy-oracle-soroban-sep40-adapter-contract-v0.1.2) - 2026-08-24
+
+### Fixed
+
+- *(proxy-oracle)* remediate Halborn findings ([#595](https://github.com/Templar-Protocol/contracts/pull/595))
+
 ## [0.1.1](https://github.com/Templar-Protocol/contracts/compare/templar-proxy-oracle-soroban-sep40-adapter-contract-v0.1.0...templar-proxy-oracle-soroban-sep40-adapter-contract-v0.1.1) - 2026-08-03
 
 ### Added

--- a/contract/proxy-oracle/soroban/sep40-adapter-contract/Cargo.toml
+++ b/contract/proxy-oracle/soroban/sep40-adapter-contract/Cargo.toml
@@ -4,7 +4,7 @@ license.workspace = true
 repository.workspace = true
 edition.workspace = true
 rust-version.workspace = true
-version = "0.1.1"
+version = "0.1.2"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/contract/pyth-lazer/contract/Cargo.toml
+++ b/contract/pyth-lazer/contract/Cargo.toml
@@ -4,7 +4,7 @@ rust-version.workspace = true
 license.workspace = true
 name = "templar-pyth-lazer-adapter-contract"
 repository.workspace = true
-version = "0.1.2"
+version = "0.1.3"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/contract/pyth-lazer/verifier/Cargo.toml
+++ b/contract/pyth-lazer/verifier/Cargo.toml
@@ -4,7 +4,7 @@ rust-version.workspace = true
 license.workspace = true
 name = "templar-pyth-lazer-verifier"
 repository.workspace = true
-version = "0.1.1"
+version = "0.1.2"
 
 [lib]
 path = "src/lib.rs"

--- a/contract/redstone-adapter/Cargo.toml
+++ b/contract/redstone-adapter/Cargo.toml
@@ -4,7 +4,7 @@ rust-version.workspace = true
 license.workspace = true
 name = "templar-redstone-adapter-contract"
 repository.workspace = true
-version = "0.2.2"
+version = "0.2.3"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/contract/registry/CHANGELOG.md
+++ b/contract/registry/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0](https://github.com/Templar-Protocol/contracts/compare/templar-registry-contract-v1.2.4...templar-registry-contract-v2.0.0) - 2026-08-24
+
+### Added
+
+- *(registry)* [**breaking**] versioned state, self-upgrade, and views for sound preflight (ENG-571, ENG-572, ENG-559, ENG-560, ENG-464) ([#589](https://github.com/Templar-Protocol/contracts/pull/589))
+- *(registry)* [**breaking**] register an existing global contract by code hash (ENG-631) ([#596](https://github.com/Templar-Protocol/contracts/pull/596))
+
 ## [1.2.2](https://github.com/Templar-Protocol/contracts/compare/templar-registry-contract-v1.2.1...templar-registry-contract-v1.2.2) - 2026-08-03
 
 ### Added

--- a/contract/registry/Cargo.toml
+++ b/contract/registry/Cargo.toml
@@ -4,7 +4,7 @@ rust-version.workspace = true
 license.workspace = true
 name = "templar-registry-contract"
 repository.workspace = true
-version = "1.2.4"
+version = "2.0.0"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/contract/universal-account/Cargo.toml
+++ b/contract/universal-account/Cargo.toml
@@ -4,7 +4,7 @@ rust-version.workspace = true
 license.workspace = true
 name = "templar-universal-account-contract"
 repository.workspace = true
-version = "0.5.3"
+version = "0.5.4"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/contract/vault/near/Cargo.toml
+++ b/contract/vault/near/Cargo.toml
@@ -6,7 +6,7 @@ name = "templar-vault-contract"
 repository.workspace = true
 # Explicit, not inherited: this crate is released on its own tag, and sharing
 # `[workspace.package].version` would drag every other inheritor along with it.
-version = "1.2.3"
+version = "1.2.4"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/gateway/artifacts-dispatch/CHANGELOG.md
+++ b/gateway/artifacts-dispatch/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/Templar-Protocol/contracts/compare/templar-gateway-artifacts-dispatch-v0.2.2...templar-gateway-artifacts-dispatch-v0.3.0) - 2026-08-24
+
+### Added
+
+- *(registry)* [**breaking**] register an existing global contract by code hash (ENG-631) ([#596](https://github.com/Templar-Protocol/contracts/pull/596))
+
 ## [0.2.0](https://github.com/Templar-Protocol/contracts/compare/templar-gateway-artifacts-dispatch-v0.1.0...templar-gateway-artifacts-dispatch-v0.2.0) - 2026-08-03
 
 ### Added

--- a/gateway/artifacts-dispatch/Cargo.toml
+++ b/gateway/artifacts-dispatch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "templar-gateway-artifacts-dispatch"
-version = "0.2.2"
+version = "0.3.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/gateway/artifacts-spec/Cargo.toml
+++ b/gateway/artifacts-spec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "templar-gateway-artifacts-spec"
-version = "0.2.2"
+version = "0.2.3"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/gateway/client/Cargo.toml
+++ b/gateway/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "templar-gateway-client"
-version = "0.2.1"
+version = "0.2.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/gateway/core/CHANGELOG.md
+++ b/gateway/core/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/Templar-Protocol/contracts/compare/templar-gateway-core-v0.3.0...templar-gateway-core-v0.4.0) - 2026-08-24
+
+### Added
+
+- *(gateway)* serve the registry's entry and version views (ENG-559, ENG-560) ([#590](https://github.com/Templar-Protocol/contracts/pull/590))
+- *(registry)* [**breaking**] register an existing global contract by code hash (ENG-631) ([#596](https://github.com/Templar-Protocol/contracts/pull/596))
+
 ## [0.3.0](https://github.com/Templar-Protocol/contracts/compare/templar-gateway-core-v0.2.0...templar-gateway-core-v0.3.0) - 2026-08-04
 
 ### Added

--- a/gateway/core/Cargo.toml
+++ b/gateway/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "templar-gateway-core"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/gateway/methods-dispatch/CHANGELOG.md
+++ b/gateway/methods-dispatch/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/Templar-Protocol/contracts/compare/templar-gateway-methods-dispatch-v0.3.0...templar-gateway-methods-dispatch-v0.4.0) - 2026-08-24
+
+### Added
+
+- *(gateway)* serve the registry's entry and version views (ENG-559, ENG-560) ([#590](https://github.com/Templar-Protocol/contracts/pull/590))
+- *(gateway)* [**breaking**] factor out the shared deploy-from-registry op structure (ENG-466) ([#594](https://github.com/Templar-Protocol/contracts/pull/594))
+- *(registry)* [**breaking**] register an existing global contract by code hash (ENG-631) ([#596](https://github.com/Templar-Protocol/contracts/pull/596))
+
 ## [0.3.0](https://github.com/Templar-Protocol/contracts/compare/templar-gateway-methods-dispatch-v0.2.0...templar-gateway-methods-dispatch-v0.3.0) - 2026-08-04
 
 ### Added

--- a/gateway/methods-dispatch/Cargo.toml
+++ b/gateway/methods-dispatch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "templar-gateway-methods-dispatch"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/gateway/methods-spec/CHANGELOG.md
+++ b/gateway/methods-spec/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/Templar-Protocol/contracts/compare/templar-gateway-methods-spec-v0.3.0...templar-gateway-methods-spec-v0.4.0) - 2026-08-24
+
+### Added
+
+- *(gateway)* serve the registry's entry and version views (ENG-559, ENG-560) ([#590](https://github.com/Templar-Protocol/contracts/pull/590))
+- *(gateway)* [**breaking**] factor out the shared deploy-from-registry op structure (ENG-466) ([#594](https://github.com/Templar-Protocol/contracts/pull/594))
+- *(registry)* [**breaking**] register an existing global contract by code hash (ENG-631) ([#596](https://github.com/Templar-Protocol/contracts/pull/596))
+
 ## [0.3.0](https://github.com/Templar-Protocol/contracts/compare/templar-gateway-methods-spec-v0.2.0...templar-gateway-methods-spec-v0.3.0) - 2026-08-04
 
 ### Added

--- a/gateway/methods-spec/Cargo.toml
+++ b/gateway/methods-spec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "templar-gateway-methods-spec"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/gateway/oracle-updates-dispatch/Cargo.toml
+++ b/gateway/oracle-updates-dispatch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "templar-gateway-oracle-updates-dispatch"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/gateway/oracle-updates-spec/Cargo.toml
+++ b/gateway/oracle-updates-spec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "templar-gateway-oracle-updates-spec"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/gateway/runtime/Cargo.toml
+++ b/gateway/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "templar-gateway-runtime"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/gateway/store/Cargo.toml
+++ b/gateway/store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "templar-gateway-store"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/gateway/types/CHANGELOG.md
+++ b/gateway/types/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/Templar-Protocol/contracts/compare/templar-gateway-types-v0.2.0...templar-gateway-types-v0.3.0) - 2026-08-24
+
+### Added
+
+- *(gateway)* serve the registry's entry and version views (ENG-559, ENG-560) ([#590](https://github.com/Templar-Protocol/contracts/pull/590))
+- *(registry)* [**breaking**] register an existing global contract by code hash (ENG-631) ([#596](https://github.com/Templar-Protocol/contracts/pull/596))
+
 ## [0.2.0](https://github.com/Templar-Protocol/contracts/compare/templar-gateway-types-v0.1.2...templar-gateway-types-v0.2.0) - 2026-08-04
 
 ### Added

--- a/gateway/types/Cargo.toml
+++ b/gateway/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "templar-gateway-types"
-version = "0.2.0"
+version = "0.3.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/primitives/CHANGELOG.md
+++ b/primitives/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/Templar-Protocol/contracts/compare/templar-primitives-v0.1.1...templar-primitives-v0.1.2) - 2026-08-24
+
+### Fixed
+
+- *(proxy-oracle)* remediate Halborn findings ([#595](https://github.com/Templar-Protocol/contracts/pull/595))
+
 ## [0.1.1](https://github.com/Templar-Protocol/contracts/compare/templar-primitives-v0.1.0...templar-primitives-v0.1.1) - 2026-08-03
 
 ### Added

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -4,7 +4,7 @@ license.workspace = true
 repository.workspace = true
 edition.workspace = true
 rust-version.workspace = true
-version = "0.1.1"
+version = "0.1.2"
 description = "Chain-agnostic numeric and decimal primitives for Templar Protocol"
 
 [dependencies]

--- a/service/accumulator/Cargo.toml
+++ b/service/accumulator/Cargo.toml
@@ -4,7 +4,7 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
-version = "0.1.4"
+version = "0.1.5"
 
 [[bin]]
 name = "accumulator"

--- a/service/funding-bridge/Cargo.toml
+++ b/service/funding-bridge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "templar-funding-bridge"
-version = "0.1.4"
+version = "0.1.5"
 edition.workspace = true
 rust-version.workspace = true
 repository.workspace = true

--- a/service/gateway/CHANGELOG.md
+++ b/service/gateway/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/Templar-Protocol/contracts/compare/templar-gateway-service-v0.4.0...templar-gateway-service-v0.5.0) - 2026-08-24
+
+### Added
+
+- *(gateway)* [**breaking**] factor out the shared deploy-from-registry op structure (ENG-466) ([#594](https://github.com/Templar-Protocol/contracts/pull/594))
+- *(registry)* [**breaking**] register an existing global contract by code hash (ENG-631) ([#596](https://github.com/Templar-Protocol/contracts/pull/596))
+
 ## [0.4.0](https://github.com/Templar-Protocol/contracts/compare/templar-gateway-service-v0.3.0...templar-gateway-service-v0.4.0) - 2026-08-07
 
 ### Added

--- a/service/gateway/Cargo.toml
+++ b/service/gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "templar-gateway-service"
-version = "0.4.0"
+version = "0.5.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/service/liquidator/Cargo.toml
+++ b/service/liquidator/Cargo.toml
@@ -4,7 +4,7 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
-version = "0.1.4"
+version = "0.1.5"
 
 [lib]
 path = "src/liquidator.rs"

--- a/service/market-monitor/Cargo.toml
+++ b/service/market-monitor/Cargo.toml
@@ -4,7 +4,7 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
-version = "0.1.2"
+version = "0.1.3"
 
 [[bin]]
 name = "market-monitor"

--- a/service/redstone-bridge/Cargo.toml
+++ b/service/redstone-bridge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "templar-redstone-bridge"
-version = "0.1.2"
+version = "0.1.3"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/service/relayer/CHANGELOG.md
+++ b/service/relayer/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/Templar-Protocol/contracts/compare/templar-relayer-v0.2.1...templar-relayer-v0.3.0) - 2026-08-24
+
+### Added
+
+- *(gateway)* [**breaking**] factor out the shared deploy-from-registry op structure (ENG-466) ([#594](https://github.com/Templar-Protocol/contracts/pull/594))
+- *(registry)* [**breaking**] register an existing global contract by code hash (ENG-631) ([#596](https://github.com/Templar-Protocol/contracts/pull/596))
+
 ## [0.2.1](https://github.com/Templar-Protocol/contracts/compare/templar-relayer-v0.2.0...templar-relayer-v0.2.1) - 2026-08-07
 
 ### Added

--- a/service/relayer/Cargo.toml
+++ b/service/relayer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "templar-relayer"
-version = "0.2.1"
+version = "0.3.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/tools/harvest-static-yield/Cargo.toml
+++ b/tools/harvest-static-yield/Cargo.toml
@@ -4,7 +4,7 @@ license.workspace = true
 repository.workspace = true
 edition.workspace = true
 rust-version.workspace = true
-version = "0.1.4"
+version = "0.1.5"
 
 [dependencies]
 anyhow.workspace = true

--- a/tools/manager/CHANGELOG.md
+++ b/tools/manager/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/Templar-Protocol/contracts/compare/templar-manager-v0.4.0...templar-manager-v0.5.0) - 2026-08-24
+
+### Added
+
+- *(manager)* make target and version preflight checks sound (ENG-559, ENG-560) ([#591](https://github.com/Templar-Protocol/contracts/pull/591))
+- *(gateway)* [**breaking**] factor out the shared deploy-from-registry op structure (ENG-466) ([#594](https://github.com/Templar-Protocol/contracts/pull/594))
+- *(registry)* [**breaking**] register an existing global contract by code hash (ENG-631) ([#596](https://github.com/Templar-Protocol/contracts/pull/596))
+
+### Fixed
+
+- *(proxy-oracle)* remediate Halborn findings ([#595](https://github.com/Templar-Protocol/contracts/pull/595))
+
 ## [0.4.0](https://github.com/Templar-Protocol/contracts/compare/templar-manager-v0.3.0...templar-manager-v0.4.0) - 2026-08-07
 
 ### Added

--- a/tools/manager/Cargo.toml
+++ b/tools/manager/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "templar-manager"
-version = "0.4.0"
+version = "0.5.0"
 edition.workspace = true
 rust-version.workspace = true
 repository.workspace = true

--- a/tools/tools-common/Cargo.toml
+++ b/tools/tools-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "templar-tools-common"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 rust-version.workspace = true
 repository.workspace = true

--- a/universal-account/Cargo.toml
+++ b/universal-account/Cargo.toml
@@ -4,7 +4,7 @@ license.workspace = true
 repository.workspace = true
 edition.workspace = true
 rust-version.workspace = true
-version = "1.2.3"
+version = "1.2.4"
 description = "Chain-abstraction account identifiers and EIP-712 signature payloads for Templar Protocol"
 
 [dependencies]


### PR DESCRIPTION



## 🤖 New release

* `templar-primitives`: 0.1.1 -> 0.1.2
* `templar-common`: 1.5.0 -> 2.0.0
* `templar-gateway-types`: 0.2.0 -> 0.3.0
* `templar-proxy-oracle-kernel`: 0.1.1 -> 0.1.2
* `templar-proxy-oracle-near-common`: 0.1.2 -> 0.1.3
* `templar-proxy-oracle-governance-kernel`: 0.2.0 -> 0.2.1
* `templar-proxy-oracle-near-governance-common`: 0.2.1 -> 0.2.2
* `templar-gateway-core`: 0.3.0 -> 0.4.0
* `templar-gateway-artifacts-dispatch`: 0.2.2 -> 0.3.0
* `templar-gateway-methods-spec`: 0.3.0 -> 0.4.0
* `templar-gateway-methods-dispatch`: 0.3.0 -> 0.4.0
* `templar-market-contract`: 1.5.0 -> 1.5.1
* `templar-relayer`: 0.2.1 -> 0.3.0
* `templar-proxy-oracle-near-contract`: 0.4.2 -> 0.4.3
* `templar-proxy-oracle-near-governance-contract`: 0.3.1 -> 0.3.2
* `templar-proxy-oracle-soroban-common`: 0.1.1 -> 0.1.2
* `templar-proxy-oracle-soroban-contract`: 0.1.1 -> 0.1.2
* `templar-proxy-oracle-soroban-governance-common`: 0.2.0 -> 0.2.1
* `templar-proxy-oracle-soroban-governance-contract`: 0.1.2 -> 0.1.3
* `templar-proxy-oracle-soroban-sep40-adapter-contract`: 0.1.1 -> 0.1.2
* `templar-registry-contract`: 1.2.4 -> 2.0.0
* `templar-manager`: 0.4.0 -> 0.5.0
* `templar-gateway-service`: 0.4.0 -> 0.5.0
* `templar-universal-account`: 1.2.3 -> 1.2.4
* `templar-gateway-artifacts-spec`: 0.2.2 -> 0.2.3
* `templar-gateway-store`: 0.2.0 -> 0.2.1
* `templar-gateway-client`: 0.2.1 -> 0.2.2
* `templar-gateway-runtime`: 0.2.0 -> 0.2.1
* `templar-pyth-lazer-verifier`: 0.1.1 -> 0.1.2
* `templar-pyth-lazer-adapter-contract`: 0.1.2 -> 0.1.3
* `templar-gateway-oracle-updates-spec`: 0.2.0 -> 0.2.1
* `templar-redstone-bridge`: 0.1.2 -> 0.1.3
* `templar-gateway-oracle-updates-dispatch`: 0.2.0 -> 0.2.1
* `templar-lst-oracle-contract`: 1.2.3 -> 1.2.4
* `templar-redstone-adapter-contract`: 0.2.2 -> 0.2.3
* `templar-universal-account-contract`: 0.5.3 -> 0.5.4
* `templar-vault-contract`: 1.2.3 -> 1.2.4
* `harvest-static-yield`: 0.1.4 -> 0.1.5
* `templar-tools-common`: 0.2.0 -> 0.2.1
* `templar-vault-client`: 1.2.3 -> 1.2.4
* `templar-accumulator`: 0.1.4 -> 0.1.5
* `templar-funding-bridge`: 0.1.4 -> 0.1.5
* `templar-liquidator`: 0.1.4 -> 0.1.5
* `templar-market-monitor`: 0.1.2 -> 0.1.3

<details><summary><i><b>Changelog</b></i></summary><p>

## `templar-primitives`

<blockquote>

## [0.1.2](https://github.com/Templar-Protocol/contracts/compare/templar-primitives-v0.1.1...templar-primitives-v0.1.2) - 2026-08-24

### Fixed

- *(proxy-oracle)* remediate Halborn findings ([#595](https://github.com/Templar-Protocol/contracts/pull/595))
</blockquote>

## `templar-common`

<blockquote>

## [2.0.0](https://github.com/Templar-Protocol/contracts/compare/templar-common-v1.5.0...templar-common-v2.0.0) - 2026-08-24

### Added

- *(common)* registry view types for sound target and version checks (ENG-559, ENG-560) ([#587](https://github.com/Templar-Protocol/contracts/pull/587))
- *(gateway)* [**breaking**] factor out the shared deploy-from-registry op structure (ENG-466) ([#594](https://github.com/Templar-Protocol/contracts/pull/594))
- *(registry)* [**breaking**] register an existing global contract by code hash (ENG-631) ([#596](https://github.com/Templar-Protocol/contracts/pull/596))

### Fixed

- *(proxy-oracle)* remediate Halborn findings ([#595](https://github.com/Templar-Protocol/contracts/pull/595))
</blockquote>

## `templar-gateway-types`

<blockquote>

## [0.3.0](https://github.com/Templar-Protocol/contracts/compare/templar-gateway-types-v0.2.0...templar-gateway-types-v0.3.0) - 2026-08-24

### Added

- *(gateway)* serve the registry's entry and version views (ENG-559, ENG-560) ([#590](https://github.com/Templar-Protocol/contracts/pull/590))
- *(registry)* [**breaking**] register an existing global contract by code hash (ENG-631) ([#596](https://github.com/Templar-Protocol/contracts/pull/596))
</blockquote>

## `templar-proxy-oracle-kernel`

<blockquote>

## [0.1.2](https://github.com/Templar-Protocol/contracts/compare/templar-proxy-oracle-kernel-v0.1.1...templar-proxy-oracle-kernel-v0.1.2) - 2026-08-24

### Fixed

- *(proxy-oracle)* remediate Halborn findings ([#595](https://github.com/Templar-Protocol/contracts/pull/595))
</blockquote>

## `templar-proxy-oracle-near-common`

<blockquote>

## [0.1.3](https://github.com/Templar-Protocol/contracts/compare/templar-proxy-oracle-near-common-v0.1.2...templar-proxy-oracle-near-common-v0.1.3) - 2026-08-24

### Fixed

- *(proxy-oracle)* remediate Halborn findings ([#595](https://github.com/Templar-Protocol/contracts/pull/595))
</blockquote>

## `templar-proxy-oracle-governance-kernel`

<blockquote>

## [0.2.1](https://github.com/Templar-Protocol/contracts/compare/templar-proxy-oracle-governance-kernel-v0.2.0...templar-proxy-oracle-governance-kernel-v0.2.1) - 2026-08-24

### Fixed

- *(proxy-oracle)* remediate Halborn findings ([#595](https://github.com/Templar-Protocol/contracts/pull/595))
</blockquote>

## `templar-proxy-oracle-near-governance-common`

<blockquote>

## [0.2.2](https://github.com/Templar-Protocol/contracts/compare/templar-proxy-oracle-near-governance-common-v0.2.1...templar-proxy-oracle-near-governance-common-v0.2.2) - 2026-08-24

### Fixed

- *(proxy-oracle)* remediate Halborn findings ([#595](https://github.com/Templar-Protocol/contracts/pull/595))
</blockquote>

## `templar-gateway-core`

<blockquote>

## [0.4.0](https://github.com/Templar-Protocol/contracts/compare/templar-gateway-core-v0.3.0...templar-gateway-core-v0.4.0) - 2026-08-24

### Added

- *(gateway)* serve the registry's entry and version views (ENG-559, ENG-560) ([#590](https://github.com/Templar-Protocol/contracts/pull/590))
- *(registry)* [**breaking**] register an existing global contract by code hash (ENG-631) ([#596](https://github.com/Templar-Protocol/contracts/pull/596))
</blockquote>

## `templar-gateway-artifacts-dispatch`

<blockquote>

## [0.3.0](https://github.com/Templar-Protocol/contracts/compare/templar-gateway-artifacts-dispatch-v0.2.2...templar-gateway-artifacts-dispatch-v0.3.0) - 2026-08-24

### Added

- *(registry)* [**breaking**] register an existing global contract by code hash (ENG-631) ([#596](https://github.com/Templar-Protocol/contracts/pull/596))
</blockquote>

## `templar-gateway-methods-spec`

<blockquote>

## [0.4.0](https://github.com/Templar-Protocol/contracts/compare/templar-gateway-methods-spec-v0.3.0...templar-gateway-methods-spec-v0.4.0) - 2026-08-24

### Added

- *(gateway)* serve the registry's entry and version views (ENG-559, ENG-560) ([#590](https://github.com/Templar-Protocol/contracts/pull/590))
- *(gateway)* [**breaking**] factor out the shared deploy-from-registry op structure (ENG-466) ([#594](https://github.com/Templar-Protocol/contracts/pull/594))
- *(registry)* [**breaking**] register an existing global contract by code hash (ENG-631) ([#596](https://github.com/Templar-Protocol/contracts/pull/596))
</blockquote>

## `templar-gateway-methods-dispatch`

<blockquote>

## [0.4.0](https://github.com/Templar-Protocol/contracts/compare/templar-gateway-methods-dispatch-v0.3.0...templar-gateway-methods-dispatch-v0.4.0) - 2026-08-24

### Added

- *(gateway)* serve the registry's entry and version views (ENG-559, ENG-560) ([#590](https://github.com/Templar-Protocol/contracts/pull/590))
- *(gateway)* [**breaking**] factor out the shared deploy-from-registry op structure (ENG-466) ([#594](https://github.com/Templar-Protocol/contracts/pull/594))
- *(registry)* [**breaking**] register an existing global contract by code hash (ENG-631) ([#596](https://github.com/Templar-Protocol/contracts/pull/596))
</blockquote>

## `templar-market-contract`

<blockquote>

## [1.5.1](https://github.com/Templar-Protocol/contracts/compare/templar-market-contract-v1.5.0...templar-market-contract-v1.5.1) - 2026-08-24

### Fixed

- *(proxy-oracle)* remediate Halborn findings ([#595](https://github.com/Templar-Protocol/contracts/pull/595))
</blockquote>

## `templar-relayer`

<blockquote>

## [0.3.0](https://github.com/Templar-Protocol/contracts/compare/templar-relayer-v0.2.1...templar-relayer-v0.3.0) - 2026-08-24

### Added

- *(gateway)* [**breaking**] factor out the shared deploy-from-registry op structure (ENG-466) ([#594](https://github.com/Templar-Protocol/contracts/pull/594))
- *(registry)* [**breaking**] register an existing global contract by code hash (ENG-631) ([#596](https://github.com/Templar-Protocol/contracts/pull/596))
</blockquote>

## `templar-proxy-oracle-near-contract`

<blockquote>

## [0.4.3](https://github.com/Templar-Protocol/contracts/compare/templar-proxy-oracle-near-contract-v0.4.2...templar-proxy-oracle-near-contract-v0.4.3) - 2026-08-24

### Fixed

- *(proxy-oracle)* remediate Halborn findings ([#595](https://github.com/Templar-Protocol/contracts/pull/595))
</blockquote>

## `templar-proxy-oracle-near-governance-contract`

<blockquote>

## [0.3.2](https://github.com/Templar-Protocol/contracts/compare/templar-proxy-oracle-near-governance-contract-v0.3.1...templar-proxy-oracle-near-governance-contract-v0.3.2) - 2026-08-24

### Fixed

- *(proxy-oracle)* remediate Halborn findings ([#595](https://github.com/Templar-Protocol/contracts/pull/595))
</blockquote>

## `templar-proxy-oracle-soroban-common`

<blockquote>

## [0.1.2](https://github.com/Templar-Protocol/contracts/compare/templar-proxy-oracle-soroban-common-v0.1.1...templar-proxy-oracle-soroban-common-v0.1.2) - 2026-08-24

### Fixed

- *(proxy-oracle)* remediate Halborn findings ([#595](https://github.com/Templar-Protocol/contracts/pull/595))
</blockquote>

## `templar-proxy-oracle-soroban-contract`

<blockquote>

## [0.1.2](https://github.com/Templar-Protocol/contracts/compare/templar-proxy-oracle-soroban-contract-v0.1.1...templar-proxy-oracle-soroban-contract-v0.1.2) - 2026-08-24

### Fixed

- *(proxy-oracle)* remediate Halborn findings ([#595](https://github.com/Templar-Protocol/contracts/pull/595))
</blockquote>

## `templar-proxy-oracle-soroban-governance-common`

<blockquote>

## [0.2.1](https://github.com/Templar-Protocol/contracts/compare/templar-proxy-oracle-soroban-governance-common-v0.2.0...templar-proxy-oracle-soroban-governance-common-v0.2.1) - 2026-08-24

### Fixed

- *(proxy-oracle)* remediate Halborn findings ([#595](https://github.com/Templar-Protocol/contracts/pull/595))
</blockquote>

## `templar-proxy-oracle-soroban-governance-contract`

<blockquote>

## [0.1.3](https://github.com/Templar-Protocol/contracts/compare/templar-proxy-oracle-soroban-governance-contract-v0.1.2...templar-proxy-oracle-soroban-governance-contract-v0.1.3) - 2026-08-24

### Fixed

- *(proxy-oracle)* remediate Halborn findings ([#595](https://github.com/Templar-Protocol/contracts/pull/595))
</blockquote>

## `templar-proxy-oracle-soroban-sep40-adapter-contract`

<blockquote>

## [0.1.2](https://github.com/Templar-Protocol/contracts/compare/templar-proxy-oracle-soroban-sep40-adapter-contract-v0.1.1...templar-proxy-oracle-soroban-sep40-adapter-contract-v0.1.2) - 2026-08-24

### Fixed

- *(proxy-oracle)* remediate Halborn findings ([#595](https://github.com/Templar-Protocol/contracts/pull/595))
</blockquote>

## `templar-registry-contract`

<blockquote>

## [2.0.0](https://github.com/Templar-Protocol/contracts/compare/templar-registry-contract-v1.2.4...templar-registry-contract-v2.0.0) - 2026-08-24

### Added

- *(registry)* [**breaking**] versioned state, self-upgrade, and views for sound preflight (ENG-571, ENG-572, ENG-559, ENG-560, ENG-464) ([#589](https://github.com/Templar-Protocol/contracts/pull/589))
- *(registry)* [**breaking**] register an existing global contract by code hash (ENG-631) ([#596](https://github.com/Templar-Protocol/contracts/pull/596))
</blockquote>

## `templar-manager`

<blockquote>

## [0.5.0](https://github.com/Templar-Protocol/contracts/compare/templar-manager-v0.4.0...templar-manager-v0.5.0) - 2026-08-24

### Added

- *(manager)* make target and version preflight checks sound (ENG-559, ENG-560) ([#591](https://github.com/Templar-Protocol/contracts/pull/591))
- *(gateway)* [**breaking**] factor out the shared deploy-from-registry op structure (ENG-466) ([#594](https://github.com/Templar-Protocol/contracts/pull/594))
- *(registry)* [**breaking**] register an existing global contract by code hash (ENG-631) ([#596](https://github.com/Templar-Protocol/contracts/pull/596))

### Fixed

- *(proxy-oracle)* remediate Halborn findings ([#595](https://github.com/Templar-Protocol/contracts/pull/595))
</blockquote>

## `templar-gateway-service`

<blockquote>

## [0.5.0](https://github.com/Templar-Protocol/contracts/compare/templar-gateway-service-v0.4.0...templar-gateway-service-v0.5.0) - 2026-08-24

### Added

- *(gateway)* [**breaking**] factor out the shared deploy-from-registry op structure (ENG-466) ([#594](https://github.com/Templar-Protocol/contracts/pull/594))
- *(registry)* [**breaking**] register an existing global contract by code hash (ENG-631) ([#596](https://github.com/Templar-Protocol/contracts/pull/596))
</blockquote>

## `templar-universal-account`

<blockquote>

## [1.2.2](https://github.com/Templar-Protocol/contracts/compare/templar-universal-account-v1.2.1...templar-universal-account-v1.2.2) - 2026-08-03

### Fixed

- *(universal-account)* decouple the EIP-712 domain version from the package version ([#554](https://github.com/Templar-Protocol/contracts/pull/554))
</blockquote>

## `templar-gateway-artifacts-spec`

<blockquote>

## [0.2.0](https://github.com/Templar-Protocol/contracts/compare/templar-gateway-artifacts-spec-v0.1.0...templar-gateway-artifacts-spec-v0.2.0) - 2026-08-03

### Added

- *(release)* [**breaking**] automate per-crate releases and version contract artifacts (ENG-522) ([#528](https://github.com/Templar-Protocol/contracts/pull/528))

### Documentation

- fix rustdoc warnings and gate them in CI ([#532](https://github.com/Templar-Protocol/contracts/pull/532))
</blockquote>

## `templar-gateway-store`

<blockquote>

## [0.2.0](https://github.com/Templar-Protocol/contracts/compare/templar-gateway-store-v0.1.2...templar-gateway-store-v0.2.0) - 2026-08-04

### Added

- *(gateway-core)* [**breaking**] serialize the write path per access key (ENG-530) ([#561](https://github.com/Templar-Protocol/contracts/pull/561))
</blockquote>

## `templar-gateway-client`

<blockquote>

## [0.2.1](https://github.com/Templar-Protocol/contracts/compare/templar-gateway-client-v0.2.0...templar-gateway-client-v0.2.1) - 2026-08-07

### Added

- *(gateway-client)* add Network::hermes_url ([#585](https://github.com/Templar-Protocol/contracts/pull/585))
</blockquote>

## `templar-gateway-runtime`

<blockquote>

## [0.2.0](https://github.com/Templar-Protocol/contracts/compare/templar-gateway-runtime-v0.1.2...templar-gateway-runtime-v0.2.0) - 2026-08-04

### Added

- *(gateway-core)* [**breaking**] serialize the write path per access key (ENG-530) ([#561](https://github.com/Templar-Protocol/contracts/pull/561))
</blockquote>

## `templar-pyth-lazer-verifier`

<blockquote>

## [0.1.1](https://github.com/Templar-Protocol/contracts/compare/templar-pyth-lazer-verifier-v0.1.0...templar-pyth-lazer-verifier-v0.1.1) - 2026-08-03

### Added

- *(release)* automate per-crate releases and version contract artifacts (ENG-522) ([#528](https://github.com/Templar-Protocol/contracts/pull/528))
</blockquote>

## `templar-pyth-lazer-adapter-contract`

<blockquote>

## [0.1.1](https://github.com/Templar-Protocol/contracts/compare/templar-pyth-lazer-adapter-contract-v0.1.0...templar-pyth-lazer-adapter-contract-v0.1.1) - 2026-08-03

### Added

- *(proxy-oracle)* standardize contract self-upgrade (ENG-481) ([#519](https://github.com/Templar-Protocol/contracts/pull/519))
- *(versioned-state)* run a chained list of migrations in one upgrade (ENG-517) ([#522](https://github.com/Templar-Protocol/contracts/pull/522))
- *(release)* automate per-crate releases and version contract artifacts (ENG-522) ([#528](https://github.com/Templar-Protocol/contracts/pull/528))

### Documentation

- fix rustdoc warnings and gate them in CI ([#532](https://github.com/Templar-Protocol/contracts/pull/532))
</blockquote>

## `templar-gateway-oracle-updates-spec`

<blockquote>

## [0.2.0](https://github.com/Templar-Protocol/contracts/compare/templar-gateway-oracle-updates-spec-v0.1.3...templar-gateway-oracle-updates-spec-v0.2.0) - 2026-08-07

### Added

- *(gateway)* [**breaking**] oracle.updatePyth fetches its own payload (ENG-462) ([#586](https://github.com/Templar-Protocol/contracts/pull/586))
</blockquote>

## `templar-redstone-bridge`

<blockquote>

## [0.1.1](https://github.com/Templar-Protocol/contracts/compare/templar-redstone-bridge-v0.1.0...templar-redstone-bridge-v0.1.1) - 2026-08-03

### Added

- *(release)* automate per-crate releases and version contract artifacts (ENG-522) ([#528](https://github.com/Templar-Protocol/contracts/pull/528))
</blockquote>

## `templar-gateway-oracle-updates-dispatch`

<blockquote>

## [0.2.0](https://github.com/Templar-Protocol/contracts/compare/templar-gateway-oracle-updates-dispatch-v0.1.3...templar-gateway-oracle-updates-dispatch-v0.2.0) - 2026-08-07

### Added

- *(gateway)* [**breaking**] oracle.updatePyth fetches its own payload (ENG-462) ([#586](https://github.com/Templar-Protocol/contracts/pull/586))
</blockquote>

## `templar-lst-oracle-contract`

<blockquote>

## [1.2.2](https://github.com/Templar-Protocol/contracts/compare/templar-lst-oracle-contract-v1.2.1...templar-lst-oracle-contract-v1.2.2) - 2026-08-03

### Added

- *(release)* automate per-crate releases and version contract artifacts (ENG-522) ([#528](https://github.com/Templar-Protocol/contracts/pull/528))
</blockquote>

## `templar-redstone-adapter-contract`

<blockquote>

## [0.2.1](https://github.com/Templar-Protocol/contracts/compare/templar-redstone-adapter-contract-v0.2.0...templar-redstone-adapter-contract-v0.2.1) - 2026-08-03

### Added

- *(release)* automate per-crate releases and version contract artifacts (ENG-522) ([#528](https://github.com/Templar-Protocol/contracts/pull/528))
</blockquote>

## `templar-universal-account-contract`

<blockquote>

## [0.5.1](https://github.com/Templar-Protocol/contracts/compare/templar-universal-account-contract-v0.5.0...templar-universal-account-contract-v0.5.1) - 2026-08-03

### Added

- add Kani invariant coverage ([#477](https://github.com/Templar-Protocol/contracts/pull/477))
- *(gateway)* configure transaction finality policy (ENG-468) ([#517](https://github.com/Templar-Protocol/contracts/pull/517))
- *(versioned-state)* run a chained list of migrations in one upgrade (ENG-517) ([#522](https://github.com/Templar-Protocol/contracts/pull/522))
- *(release)* automate per-crate releases and version contract artifacts (ENG-522) ([#528](https://github.com/Templar-Protocol/contracts/pull/528))
</blockquote>

## `templar-vault-contract`

<blockquote>

## [1.2.2](https://github.com/Templar-Protocol/contracts/compare/templar-vault-contract-v1.2.1...templar-vault-contract-v1.2.2) - 2026-08-03

### Added

- *(release)* automate per-crate releases and version contract artifacts (ENG-522) ([#528](https://github.com/Templar-Protocol/contracts/pull/528))
</blockquote>

## `harvest-static-yield`

<blockquote>

## [0.1.1](https://github.com/Templar-Protocol/contracts/compare/harvest-static-yield-v0.1.0...harvest-static-yield-v0.1.1) - 2026-08-03

### Added

- *(release)* automate per-crate releases and version contract artifacts (ENG-522) ([#528](https://github.com/Templar-Protocol/contracts/pull/528))
</blockquote>

## `templar-tools-common`

<blockquote>

## [0.2.0](https://github.com/Templar-Protocol/contracts/compare/templar-tools-common-v0.1.3...templar-tools-common-v0.2.0) - 2026-08-07

### Changed

- *(tools-common)* [**breaking**] drop the unused NEAR client layer ([#579](https://github.com/Templar-Protocol/contracts/pull/579))
</blockquote>

## `templar-vault-client`

<blockquote>

## [1.2.2](https://github.com/Templar-Protocol/contracts/compare/templar-vault-client-v1.2.1...templar-vault-client-v1.2.2) - 2026-08-03

### Added

- *(release)* automate per-crate releases and version contract artifacts (ENG-522) ([#528](https://github.com/Templar-Protocol/contracts/pull/528))
</blockquote>

## `templar-accumulator`

<blockquote>

## [0.1.1](https://github.com/Templar-Protocol/contracts/compare/templar-accumulator-v0.1.0...templar-accumulator-v0.1.1) - 2026-08-03

### Added

- *(release)* automate per-crate releases and version contract artifacts (ENG-522) ([#528](https://github.com/Templar-Protocol/contracts/pull/528))

### Documentation

- fix rustdoc warnings and gate them in CI ([#532](https://github.com/Templar-Protocol/contracts/pull/532))
</blockquote>

## `templar-funding-bridge`

<blockquote>

## [0.1.1](https://github.com/Templar-Protocol/contracts/compare/templar-funding-bridge-v0.1.0...templar-funding-bridge-v0.1.1) - 2026-08-03

### Added

- *(release)* automate per-crate releases and version contract artifacts (ENG-522) ([#528](https://github.com/Templar-Protocol/contracts/pull/528))

### Documentation

- fix rustdoc warnings and gate them in CI ([#532](https://github.com/Templar-Protocol/contracts/pull/532))
</blockquote>

## `templar-liquidator`

<blockquote>

## [0.1.4](https://github.com/Templar-Protocol/contracts/compare/templar-liquidator-v0.1.3...templar-liquidator-v0.1.4) - 2026-08-07

### Added

- *(gateway)* [**breaking**] oracle.updatePyth fetches its own payload (ENG-462) ([#586](https://github.com/Templar-Protocol/contracts/pull/586))
</blockquote>

## `templar-market-monitor`

<blockquote>

## [0.1.1](https://github.com/Templar-Protocol/contracts/compare/templar-market-monitor-v0.1.0...templar-market-monitor-v0.1.1) - 2026-08-03

### Added

- *(release)* automate per-crate releases and version contract artifacts (ENG-522) ([#528](https://github.com/Templar-Protocol/contracts/pull/528))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/592)
<!-- Reviewable:end -->
