### PR TITLE
feat(gateway): reject a code-hash version against a registry too old for it (ENG-631)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13047,6 +13047,7 @@ dependencies = [
  "near-sandbox",
  "near-sdk",
  "near-token",
+ "rstest",
  "serde",
  "serde_json",
  "serde_json_canonicalizer",

--- a/gateway/core/Cargo.toml
+++ b/gateway/core/Cargo.toml
@@ -48,5 +48,6 @@ templar-gateway-methods-dispatch = { path = "../methods-dispatch" }
 templar-gateway-methods-spec.workspace = true
 near-sandbox.workspace = true
 near-token.workspace = true
+rstest.workspace = true
 templar-gateway-testing.workspace = true
 tokio.workspace = true

--- a/gateway/core/src/client/registry.rs
+++ b/gateway/core/src/client/registry.rs
@@ -86,15 +86,14 @@ impl RegistryClient<'_> {
     ) -> GatewayResult<PlannedTransaction> {
         let args = args.borrow();
         // Exhaustive on purpose: a new source must state which release first accepts it, rather
-        // than defaulting to "every registry understands this". `ExistingGlobal` has no gate yet —
-        // the release that introduces it has no version number until it ships. Pre-1.1.0 has no
-        // encoding for a code hash and `encode_add_version_args` rejects it below; between there
-        // and that release the call encodes fine and fails on chain.
+        // than defaulting to "every registry understands this".
         let unsupported = match args.source {
-            VersionSource::Stored(_) | VersionSource::ExistingGlobal(_) => None,
+            VersionSource::Stored(_) => None,
             VersionSource::PublishGlobal(_) => {
                 (!registry_version.supports_global_contracts()).then_some("global contracts")
             }
+            VersionSource::ExistingGlobal(_) => (!registry_version.supports_existing_global())
+                .then_some("registering a version by code hash"),
         };
         if let Some(feature) = unsupported {
             return Err(std::io::Error::new(

--- a/gateway/core/src/client/registry.rs
+++ b/gateway/core/src/client/registry.rs
@@ -141,3 +141,85 @@ impl RegistryClient<'_> {
         pub fn remove_version(RemoveVersionArgs);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use near_api::{types::transaction::actions::Action, NetworkConfig};
+    use near_sdk::json_types::{Base58CryptoHash, Base64VecU8};
+    use templar_common::registry::VersionSource;
+    use templar_gateway_types::{ManagedAccountId, RegistryVersion};
+
+    use super::{AddVersionArgs, NearClient};
+    use crate::client::ContractWriteOptions;
+
+    const CODE: [u8; 3] = [0xde, 0xad, 0xbe];
+
+    fn plan(
+        version: (u64, u64, u64),
+        source: VersionSource,
+    ) -> crate::GatewayResult<crate::operation::PlannedTransaction> {
+        let client = NearClient::new(NetworkConfig::from_rpc_url(
+            "test",
+            "http://127.0.0.1:1".parse().unwrap(),
+        ));
+        client
+            .registry("registry.near".parse().unwrap())
+            .add_version(
+                ContractWriteOptions::new(ManagedAccountId("owner.near".parse().unwrap()))
+                    .one_yocto(),
+                RegistryVersion::from(version),
+                AddVersionArgs {
+                    version_key: "market@1.5.0".to_owned(),
+                    source,
+                },
+            )
+    }
+
+    #[rstest::rstest]
+    #[case::stored(VersionSource::Stored(Base64VecU8(CODE.to_vec())))]
+    #[case::publish_global(VersionSource::PublishGlobal(Base64VecU8(CODE.to_vec())))]
+    #[case::existing_global(VersionSource::ExistingGlobal(Base58CryptoHash::from([7u8; 32])))]
+    fn every_source_plans_against_2_0_0(#[case] source: VersionSource) {
+        let planned = plan((2, 0, 0), source).expect("2.0.0 accepts every source");
+
+        let [Action::FunctionCall(action)] = &planned.actions[..] else {
+            panic!("expected one function call");
+        };
+        assert_eq!(action.method_name, "add_version");
+    }
+
+    /// The release before the one carrying `ExistingGlobal`: rejected while planning, so nothing
+    /// reaches the chain to fail there.
+    #[test]
+    fn existing_global_is_refused_below_2_0_0() {
+        let error = plan(
+            (1, 2, 4),
+            VersionSource::ExistingGlobal(Base58CryptoHash::from([7u8; 32])),
+        )
+        .expect_err("1.2.4 cannot read a code hash");
+
+        let crate::GatewayError::Io(io) = &error else {
+            panic!("expected an io error: {error}");
+        };
+        assert_eq!(io.kind(), std::io::ErrorKind::InvalidData);
+        assert!(
+            error.to_string().contains("code hash"),
+            "error should name the unsupported feature: {error}"
+        );
+    }
+
+    /// `PublishGlobal` keeps its own older gate, so the two thresholds cannot be collapsed.
+    #[test]
+    fn publish_global_is_refused_below_1_1_0() {
+        let error = plan(
+            (1, 0, 0),
+            VersionSource::PublishGlobal(Base64VecU8(CODE.to_vec())),
+        )
+        .expect_err("1.0.0 has no global contracts");
+
+        assert!(
+            error.to_string().contains("global contracts"),
+            "error should name the unsupported feature: {error}"
+        );
+    }
+}

--- a/gateway/methods-dispatch/src/registry_impl.rs
+++ b/gateway/methods-dispatch/src/registry_impl.rs
@@ -65,7 +65,7 @@ async fn require_entry_and_version_views<C: HasNearClient>(
     if !version.supports_entry_and_version_views() {
         return Err(GatewayError::UnsupportedFeature(format!(
             "registry {registry_id} is version {version}; \
-             getRegistryEntry and getVersion require 1.3.0"
+             getRegistryEntry and getVersion require 2.0.0"
         )));
     }
 

--- a/gateway/types/src/version/registry_version.rs
+++ b/gateway/types/src/version/registry_version.rs
@@ -14,7 +14,7 @@ impl RegistryVersion {
     /// a reserved name. Every registry deployed so far predates them — the live ones run 0.1.0,
     /// 1.0.0 and 1.1.0 — so a caller must degrade to the older checks rather than fail closed.
     pub fn supports_entry_and_version_views(self) -> bool {
-        self >= (1, 3, 0)
+        self >= (2, 0, 0)
     }
 
     pub fn deploy_method_name(self) -> &'static str {
@@ -23,6 +23,12 @@ impl RegistryVersion {
         } else {
             "deploy_market"
         }
+    }
+
+    /// Whether `add_version` accepts [`VersionSource::ExistingGlobal`] — pointing a version key at
+    /// a global contract already on chain instead of paying to publish those bytes again.
+    pub fn supports_existing_global(self) -> bool {
+        self >= (2, 0, 0)
     }
 
     /// Lower a [`VersionSource`] onto the encoding the target registry actually parses.
@@ -59,6 +65,21 @@ mod tests {
 
     const KEY: &str = "market@1.5.0";
     const CODE: [u8; 3] = [0xde, 0xad, 0xbe];
+
+    /// Every release before the one carrying `ExistingGlobal` must read as unsupported, so a
+    /// caller is rejected up front rather than sending an encoding the registry cannot parse.
+    #[rstest::rstest]
+    #[case((0, 1, 0), false)]
+    #[case((1, 1, 0), false)]
+    #[case((1, 2, 4), false)]
+    #[case((1, 3, 0), false)]
+    #[case((2, 0, 0), true)]
+    fn existing_global_from_2_0_0(#[case] version: (u64, u64, u64), #[case] expected: bool) {
+        assert_eq!(
+            RegistryVersion::from(version).supports_existing_global(),
+            expected,
+        );
+    }
 
     /// The whole point of the fold: a 1.1.0+ registry sees exactly the bytes it saw before.
     #[rstest::rstest]
@@ -110,9 +131,9 @@ mod tests {
     #[case::v1_tmplr_near((1, 0, 0), false)]
     #[case::user0_tmplr_near((1, 1, 0), false)]
     #[case((1, 2, 4), false)]
-    #[case((1, 3, 0), true)]
+    #[case((1, 3, 0), false)]
     #[case((2, 0, 0), true)]
-    fn entry_and_version_views_from_1_3_0(
+    fn entry_and_version_views_from_2_0_0(
         #[case] version: (u64, u64, u64),
         #[case] expected: bool,
     ) {


### PR DESCRIPTION
Closes the last piece of ENG-631. Now unblocked: #596 merged and the registry released as **2.0.0** carrying `VersionSource::ExistingGlobal`, so the version this check keys on finally exists.

## What it does

`supports_existing_global()` gates on 2.0.0. Below it the client rejects at preflight instead of letting the call fail on chain, where a 1.1.0–1.2.4 registry would try to read discriminant 2 as a `DeployMode` and simply fail to deserialize.

The match in `add_version` becomes exhaustive again, so a future `VersionSource` variant has to state which release first accepts it rather than defaulting to "every registry understands this".

## `supports_entry_and_version_views` moves too

It gated on `1.3.0` — a version that never existed and now never will. The views it guards shipped in 2.0.0 (#589), and the registry went 1.2.4 → 2.0.0, so the old bound accepted a phantom range. Both gates now name the release that actually carries the feature.

The user-facing dispatch error moves with it: `registry_impl.rs` told operators that `getRegistryEntry` and `getVersion` "require 1.3.0", which no registry could ever satisfy.

## Verification

`cargo check --workspace --tests`, `cargo clippy --all-features --workspace --tests -- -D warnings` and `cargo fmt --all --check` clean; fast gate `5306/5306`.

`add_version_accepts_every_source_and_each_one_deploys` was red by construction on the old stack — the sandbox registry built from source at 1.2.4, below the gate. It builds at 2.0.0 now, so it passes without changes here.

## Note for review

This does nothing for the registries actually deployed. `templar-alpha.near` (0.1.0), `v1.tmplr.near` (1.0.0) and `user0.tmplr.near` (1.1.0) all sit below 2.0.0, so `getRegistryEntry`/`getVersion` stay unavailable against every live registry — the gate is honest about that rather than fixing it. Worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/597)
<!-- Reviewable:end -->
