### PR TITLE
chore(artifacts): record released contract WASMs

### DIFF
--- a/contract/artifacts/releases/registry@2.0.0.tsv
+++ b/contract/artifacts/releases/registry@2.0.0.tsv
@@ -1,0 +1,1 @@
+registry	2.0.0	templar-registry-contract-v2.0.0	templar_registry_contract-2.0.0.wasm	d2644ad9a98f23da10a59952faf73a35896c7c12b5c29876f41fb40d411a6d3b	287419


### PR DESCRIPTION
Records the contract WASMs CI built at their release tags and
published, one file per release under
`contract/artifacts/releases/`:

| Artifact | Version | Tag | SHA-256 | Bytes |
| --- | --- | --- | --- | --- |
| `registry` | 2.0.0 | `templar-registry-contract-v2.0.0` | `d2644ad9a98f23da10a59952faf73a35896c7c12b5c29876f41fb40d411a6d3b` | 287419 |

Until this merges, `templar-contract-artifacts` will not serve these
versions — an unrecorded version has no reviewed hash to check
downloaded bytes against.

Reproduce any row from a fresh clone, against the artifact's crate
directory:

    git checkout <tag>
    cargo near build reproducible-wasm --manifest-path <crate>/Cargo.toml

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/605)
<!-- Reviewable:end -->
