### PR TITLE
chore(artifacts): record released contract WASMs

### DIFF
--- a/contract/artifacts/releases/patch-state@0.1.0.tsv
+++ b/contract/artifacts/releases/patch-state@0.1.0.tsv
@@ -1,0 +1,1 @@
+patch-state	0.1.0	templar-patch-state-contract-v0.1.0	templar_patch_state_contract-0.1.0.wasm	28f8e6d145b6af238d806829ab27a5952b20c33886d0f34039691579f838f37f	9592


### PR DESCRIPTION
Records the contract WASMs CI built at their release tags and
published, one file per release under
`contract/artifacts/releases/`:

| Artifact | Version | Tag | SHA-256 | Bytes |
| --- | --- | --- | --- | --- |
| `patch-state` | 0.1.0 | `templar-patch-state-contract-v0.1.0` | `28f8e6d145b6af238d806829ab27a5952b20c33886d0f34039691579f838f37f` | 9592 |

Until this merges, `templar-contract-artifacts` will not serve these
versions — an unrecorded version has no reviewed hash to check
downloaded bytes against.

Reproduce any row from a fresh clone, against the artifact's crate
directory:

    git checkout <tag>
    cargo near build reproducible-wasm --manifest-path <crate>/Cargo.toml

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/606)
<!-- Reviewable:end -->
