### PR TITLE
feat(gateway)!: validate registry init args against ABI (ENG-463)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,6 +150,7 @@ dependencies = [
  "cfg-if 1.0.4",
  "getrandom 0.3.4",
  "once_cell",
+ "serde",
  "version_check",
  "zerocopy",
 ]
@@ -813,7 +814,7 @@ dependencies = [
  "ark-serialize 0.3.0",
  "ark-std 0.3.0",
  "derivative",
- "num-bigint 0.4.6",
+ "num-bigint 0.4.8",
  "num-traits",
  "paste",
  "rustc_version 0.3.3",
@@ -833,7 +834,7 @@ dependencies = [
  "derivative",
  "digest 0.10.7",
  "itertools 0.10.5",
- "num-bigint 0.4.6",
+ "num-bigint 0.4.8",
  "num-traits",
  "paste",
  "rustc_version 0.4.1",
@@ -854,7 +855,7 @@ dependencies = [
  "digest 0.10.7",
  "educe",
  "itertools 0.13.0",
- "num-bigint 0.4.6",
+ "num-bigint 0.4.8",
  "num-traits",
  "paste",
  "zeroize",
@@ -896,7 +897,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db2fd794a08ccb318058009eefdf15bcaaaaf6f8161eb3345f907222bac38b20"
 dependencies = [
- "num-bigint 0.4.6",
+ "num-bigint 0.4.8",
  "num-traits",
  "quote",
  "syn 1.0.109",
@@ -908,7 +909,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
 dependencies = [
- "num-bigint 0.4.6",
+ "num-bigint 0.4.8",
  "num-traits",
  "proc-macro2",
  "quote",
@@ -921,7 +922,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09be120733ee33f7693ceaa202ca41accd5653b779563608f1234f78ae07c4b3"
 dependencies = [
- "num-bigint 0.4.6",
+ "num-bigint 0.4.8",
  "num-traits",
  "proc-macro2",
  "quote",
@@ -960,7 +961,7 @@ dependencies = [
  "ark-serialize-derive",
  "ark-std 0.4.0",
  "digest 0.10.7",
- "num-bigint 0.4.6",
+ "num-bigint 0.4.8",
 ]
 
 [[package]]
@@ -972,7 +973,7 @@ dependencies = [
  "ark-std 0.5.0",
  "arrayvec",
  "digest 0.10.7",
- "num-bigint 0.4.6",
+ "num-bigint 0.4.8",
 ]
 
 [[package]]
@@ -1786,6 +1787,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "borrow-or-share"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
+
+[[package]]
 name = "borsh"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1982,7 +1989,7 @@ version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0adabf37211a5276e46335feabcbb1530c95eb3fdf85f324c7db942770aa025d"
 dependencies = [
- "num-bigint 0.4.6",
+ "num-bigint 0.4.8",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -3844,6 +3851,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fancy-regex"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "476de73bddf2ef8490aa4ee8f1cf40b430bf1d56c48c22080e5186952cd580e6"
+dependencies = [
+ "bit-set 0.8.0",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "fastrand"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4006,6 +4024,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fluent-uri"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc74ac4d8359ae70623506d512209619e5cf8f347124910440dbc221714b328e"
+dependencies = [
+ "borrow-or-share",
+ "ref-cast",
+ "serde",
+]
+
+[[package]]
 name = "flume"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4056,6 +4085,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fraction"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fee0259ffdc3d7bd64438b6b08437884d4df5700f9cb8a23b079c3958ae578"
+dependencies = [
+ "num",
+ "num-bigint 0.4.8",
 ]
 
 [[package]]
@@ -4483,6 +4522,17 @@ dependencies = [
  "foldhash 0.2.0",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -5380,6 +5430,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonschema"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "152999731bfbe0bb82d561550be73b0c31a9827d6ebe3fe96ad47563703b5328"
+dependencies = [
+ "ahash 0.8.12",
+ "bytecount",
+ "data-encoding",
+ "email_address",
+ "fancy-regex",
+ "fraction",
+ "getrandom 0.3.4",
+ "idna",
+ "itoa",
+ "jsonschema-regex",
+ "jsonschema-value",
+ "num-cmp",
+ "num-traits",
+ "percent-encoding",
+ "referencing",
+ "regex",
+ "serde",
+ "serde_json",
+ "strum 0.28.0",
+ "unicode-general-category",
+ "uuid-simd",
+]
+
+[[package]]
+name = "jsonschema-regex"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cb2e614e1c610e31e947d53156e877340c718e053cfce0dfe9b9ce7beff4d31"
+dependencies = [
+ "regex-syntax",
+]
+
+[[package]]
+name = "jsonschema-value"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24373bc85409cb935a46af0ffb41294c5372c08cf9b0709913d908154cd10582"
+dependencies = [
+ "ahash 0.8.12",
+ "bytecount",
+ "fraction",
+ "num-cmp",
+ "num-traits",
+ "serde_json",
+]
+
+[[package]]
 name = "jsonwebtoken"
 version = "8.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5782,6 +5884,12 @@ dependencies = [
  "rand_core 0.6.4",
  "zeroize",
 ]
+
+[[package]]
+name = "micromap"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a86d3146ed3995b5913c414f6664344b9617457320782e64f0bb44afd49d74"
 
 [[package]]
 name = "mime"
@@ -6501,7 +6609,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
 dependencies = [
- "num-bigint 0.4.6",
+ "num-bigint 0.4.8",
  "num-complex",
  "num-integer",
  "num-iter",
@@ -6522,9 +6630,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.6"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -6545,6 +6653,12 @@ dependencies = [
  "smallvec",
  "zeroize",
 ]
+
+[[package]]
+name = "num-cmp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa"
 
 [[package]]
 name = "num-complex"
@@ -6611,7 +6725,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
 dependencies = [
- "num-bigint 0.4.6",
+ "num-bigint 0.4.8",
  "num-integer",
  "num-traits",
 ]
@@ -7840,6 +7954,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "referencing"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aff997fc7eecb671a947b0f73f5ce4bcb4ad3534fd5bff2dd752718a8107525"
+dependencies = [
+ "ahash 0.8.12",
+ "fluent-uri",
+ "getrandom 0.3.4",
+ "hashbrown 0.17.1",
+ "itoa",
+ "micromap",
+ "parking_lot",
+ "percent-encoding",
+ "serde_json",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7853,9 +7984,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -8194,7 +8325,7 @@ dependencies = [
  "bytes",
  "fastrlp 0.3.1",
  "fastrlp 0.4.0",
- "num-bigint 0.4.6",
+ "num-bigint 0.4.8",
  "num-integer",
  "num-traits",
  "parity-scale-codec",
@@ -9048,7 +9179,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "297f631f50729c8c99b84667867963997ec0b50f32b2a7dbcab828ef0541e8bb"
 dependencies = [
- "num-bigint 0.4.6",
+ "num-bigint 0.4.8",
  "num-traits",
  "thiserror 2.0.18",
  "time",
@@ -9356,7 +9487,7 @@ version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75db7f2bbac3e62cfd139065d15bcda9e2428883ba61fc8d27ccb251081e7567"
 dependencies = [
- "num-bigint 0.4.6",
+ "num-bigint 0.4.8",
  "num-traits",
  "solana-define-syscall 2.3.0",
 ]
@@ -9367,7 +9498,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30c80fb6d791b3925d5ec4bf23a7c169ef5090c013059ec3ed7d0b2c04efa085"
 dependencies = [
- "num-bigint 0.4.6",
+ "num-bigint 0.4.8",
  "num-traits",
  "solana-define-syscall 3.0.0",
 ]
@@ -10211,7 +10342,7 @@ dependencies = [
  "lazy_static",
  "log",
  "memoffset 0.9.1",
- "num-bigint 0.4.6",
+ "num-bigint 0.4.8",
  "num-derive",
  "num-traits",
  "rand 0.8.5",
@@ -12382,7 +12513,7 @@ dependencies = [
  "ed25519",
  "ed25519-dalek",
  "json",
- "num-bigint 0.4.6",
+ "num-bigint 0.4.8",
  "num-rational 0.4.2",
  "num-traits",
  "rand 0.8.5",
@@ -12592,6 +12723,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros 0.28.0",
+]
+
+[[package]]
 name = "strum_macros"
 version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12622,6 +12762,18 @@ name = "strum_macros"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -13036,6 +13188,8 @@ dependencies = [
  "actix",
  "anyhow",
  "async-trait",
+ "base64 0.22.1",
+ "borsh 1.6.1",
  "chrono",
  "futures",
  "hex",
@@ -13083,13 +13237,17 @@ version = "0.4.0"
 dependencies = [
  "async-trait",
  "borsh 1.6.1",
+ "jsonschema",
+ "near-abi",
  "near-account-id",
  "near-api",
  "near-contract-standards",
  "serde",
  "serde_json",
  "serde_json_canonicalizer",
+ "sha2 0.10.9",
  "templar-common",
+ "templar-contract-artifacts",
  "templar-gateway-core",
  "templar-gateway-methods-spec",
  "templar-gateway-types",
@@ -13099,6 +13257,8 @@ dependencies = [
  "templar-proxy-oracle-near-governance-common",
  "templar-universal-account",
  "tokio",
+ "wasmparser 0.244.0",
+ "zstd 0.13.3",
 ]
 
 [[package]]
@@ -13234,6 +13394,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "wiremock",
+ "zstd 0.13.3",
 ]
 
 [[package]]
@@ -14825,6 +14986,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
+name = "unicode-general-category"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b993bddc193ae5bd0d623b49ec06ac3e9312875fdae725a975c51db1cc1677f"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15144,6 +15311,16 @@ dependencies = [
  "js-sys",
  "serde_core",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "uuid-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b082222b4f6619906941c17eb2297fff4c2fb96cb60164170522942a200bd8"
+dependencies = [
+ "outref",
+ "vsimd",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13242,6 +13242,7 @@ dependencies = [
  "near-account-id",
  "near-api",
  "near-contract-standards",
+ "rstest",
  "serde",
  "serde_json",
  "serde_json_canonicalizer",

--- a/contract/registry/tests/deployment.rs
+++ b/contract/registry/tests/deployment.rs
@@ -85,7 +85,7 @@ async fn deploy_from_registry(#[future(awt)] harness: SandboxHarness) -> Result<
         let args = args.clone();
         async move {
             harness
-                .registry_deploy(
+                .registry_deploy_without_abi_check(
                     &registry.deployer,
                     &registry.id,
                     name,
@@ -118,7 +118,7 @@ async fn deploy_with_access_key(#[future(awt)] harness: SandboxHarness) -> Resul
     let key = PublicKey::from(TEST_PUBLIC_KEY.parse::<near_api::types::PublicKey>()?);
 
     harness
-        .registry_deploy(
+        .registry_deploy_without_abi_check(
             &registry.deployer,
             &registry.id,
             "market",
@@ -191,7 +191,7 @@ async fn deploy_from_a_version_registered_by_code_hash(
     );
 
     harness
-        .registry_deploy(
+        .registry_deploy_without_abi_check(
             &registry.deployer,
             &registry.id,
             "by-hash",
@@ -279,7 +279,7 @@ async fn market_id_collision(#[future(awt)] harness: SandboxHarness) -> Result<(
     let args = init_args(&registry.configuration)?;
 
     harness
-        .registry_deploy(
+        .registry_deploy_without_abi_check(
             &registry.deployer,
             &registry.id,
             "market",
@@ -291,7 +291,7 @@ async fn market_id_collision(#[future(awt)] harness: SandboxHarness) -> Result<(
         .await?;
     // Re-deploying the same name collides.
     let result = harness
-        .registry_deploy(
+        .registry_deploy_without_abi_check(
             &registry.deployer,
             &registry.id,
             "market",

--- a/contract/registry/tests/migration.rs
+++ b/contract/registry/tests/migration.rs
@@ -84,7 +84,7 @@ async fn populate(harness: &SandboxHarness, registry_id: &AccountId) -> Result<P
         YieldWeights::new_with_supply_weight(1),
     );
     harness
-        .registry_deploy(
+        .registry_deploy_without_abi_check(
             &deployer,
             registry_id,
             "market",

--- a/gateway/METHODS.md
+++ b/gateway/METHODS.md
@@ -203,7 +203,7 @@
 |---|---|---|---|
 | `registry.addArtifactVersion` | write | `AddArtifactVersion` → `WriteOperationResult` | Add a contract artifact version to a registry. |
 | `registry.addVersion` | write | `AddVersion` → `WriteOperationResult` | Add a deployable version to a registry. |
-| `registry.deploy` | write | `Deploy` → `WriteOperationResult` | Deploy a contract from a registry version, with init args the gateway does not interpret. |
+| `registry.deploy` | write | `Deploy` → `WriteOperationResult` | Deploy a contract from a registry version with JSON init args validated against the target constructor ABI unless `skip_abi_check` is set. |
 | `registry.getDeployment` | read | `GetDeployment` → `GetDeploymentResult` | Get a deployment record from a registry. |
 | `registry.getRegistryEntry` | read | `GetRegistryEntry` → `GetRegistryEntryResult` | Get a name's registry entry, including one merely reserved by an in-flight deploy. |
 | `registry.getVersion` | read | `GetVersion` → `GetVersionResult` | Get a registered version's code hash and whether it can still be deployed. |

--- a/gateway/core/Cargo.toml
+++ b/gateway/core/Cargo.toml
@@ -9,6 +9,8 @@ description = "Core actor, operation, and execution-outcome model for the Templa
 
 [dependencies]
 actix.workspace = true
+borsh.workspace = true
+base64.workspace = true
 async-trait.workspace = true
 chrono.workspace = true
 futures.workspace = true

--- a/gateway/core/src/client/registry.rs
+++ b/gateway/core/src/client/registry.rs
@@ -2,6 +2,7 @@ use std::{borrow::Borrow, io::ErrorKind};
 
 use near_account_id::AccountId;
 use near_api::types::transaction::actions::{Action, FunctionCallAction};
+use near_sdk::json_types::Base58CryptoHash;
 use templar_common::registry::VersionSource;
 use templar_gateway_types::{
     common::{ContractArgs, Pagination},
@@ -32,6 +33,13 @@ pub struct GetRegistryEntryArgs {
 #[derive(Debug, serde::Serialize)]
 pub struct GetVersionArgs {
     pub version_key: String,
+}
+
+#[derive(Debug, serde::Serialize)]
+pub struct GetVersionCodeChunkArgs {
+    pub version_key: String,
+    pub offset: u32,
+    pub len: u32,
 }
 
 #[derive(Debug)]
@@ -74,8 +82,22 @@ impl RegistryClient<'_> {
         pub fn get_deployment(GetDeploymentArgs) -> Option<templar_common::registry::Deployment>;
         pub fn get_registry_entry(GetRegistryEntryArgs) -> Option<templar_common::registry::RegistryEntryView>;
         pub fn get_version(GetVersionArgs) -> Option<templar_common::registry::VersionInfo>;
+        pub fn get_version_code_hash(GetVersionArgs) -> Option<Base58CryptoHash>;
         pub fn list_deployments(Pagination) -> Vec<AccountId>;
         pub fn list_versions(Pagination) -> Vec<String>;
+    }
+
+    pub async fn get_version_code_chunk(
+        &self,
+        args: impl Borrow<GetVersionCodeChunkArgs>,
+    ) -> GatewayResult<Option<Vec<u8>>> {
+        crate::ReadNear::view_function_borsh(
+            self.inner,
+            self.contract_id.clone(),
+            "get_version_code_chunk",
+            serde_json::to_vec(args.borrow())?,
+        )
+        .await
     }
 
     pub fn add_version(

--- a/gateway/core/src/error.rs
+++ b/gateway/core/src/error.rs
@@ -10,6 +10,8 @@ pub enum GatewayError {
     HttpRequest(String),
     #[error("near query failed: {0}")]
     NearQuery(String),
+    #[error("global contract code not found: {0}")]
+    GlobalContractCodeNotFound(String),
     #[error("account not found: {0}")]
     AccountNotFound(near_account_id::AccountId),
     #[error("unsupported signer account: {0}")]

--- a/gateway/core/src/error.rs
+++ b/gateway/core/src/error.rs
@@ -18,6 +18,8 @@ pub enum GatewayError {
     UnsupportedSignerAccount(String),
     #[error("request precondition failed: {0}")]
     RequestPreconditionFailed(String),
+    #[error("internal gateway error: {0}")]
+    Internal(String),
     #[error("invalid signer key: {0}")]
     InvalidSignerKey(String),
     #[error("near transaction failed: {0}")]

--- a/gateway/core/src/read.rs
+++ b/gateway/core/src/read.rs
@@ -1,4 +1,6 @@
 use async_trait::async_trait;
+use base64::Engine;
+use borsh::BorshDeserialize;
 use near_api::types::{
     account::Account,
     transaction::{actions::AccessKey, result::ExecutionFinalResult},
@@ -19,6 +21,17 @@ pub trait ReadNear: Send + Sync {
     ) -> GatewayResult<T>
     where
         T: DeserializeOwned + Send + Sync + 'static;
+
+    async fn view_function_borsh<T>(
+        &self,
+        contract_id: near_account_id::AccountId,
+        method_name: &str,
+        args: Vec<u8>,
+    ) -> GatewayResult<T>
+    where
+        T: BorshDeserialize + Send + Sync + 'static;
+
+    async fn view_global_contract_code(&self, code_hash: CryptoHash) -> GatewayResult<Vec<u8>>;
 
     async fn view_account(&self, account_id: near_account_id::AccountId) -> GatewayResult<Account>;
 
@@ -54,12 +67,40 @@ impl ReadNear for NearClient {
             .fetch_from(self.network())
             .await
             .map(|response| response.data)
+            .map_err(|error| account_query_error(contract_id, &error))
+    }
+
+    async fn view_function_borsh<T>(
+        &self,
+        contract_id: near_account_id::AccountId,
+        method_name: &str,
+        args: Vec<u8>,
+    ) -> GatewayResult<T>
+    where
+        T: BorshDeserialize + Send + Sync + 'static,
+    {
+        Contract(contract_id.clone())
+            .call_function_raw(method_name, args)
+            .read_only_borsh()
+            .at(self.finality_policy().query_reference())
+            .fetch_from(self.network())
+            .await
+            .map(|response| response.data)
+            .map_err(|error| account_query_error(contract_id, &error))
+    }
+
+    async fn view_global_contract_code(&self, code_hash: CryptoHash) -> GatewayResult<Vec<u8>> {
+        let code = Contract::global_wasm()
+            .by_hash(code_hash)
+            .at(self.finality_policy().query_reference())
+            .fetch_from(self.network())
+            .await
+            .map_err(|error| global_code_query_error(&error))?;
+
+        base64::engine::general_purpose::STANDARD
+            .decode(code.data.code_base64)
             .map_err(|error| {
-                if is_unknown_account(&error) {
-                    GatewayError::AccountNotFound(contract_id)
-                } else {
-                    GatewayError::NearQuery(error.to_string())
-                }
+                GatewayError::NearQuery(format!("invalid global contract code: {error}"))
             })
     }
 
@@ -69,13 +110,7 @@ impl ReadNear for NearClient {
             .at(self.finality_policy().query_reference())
             .fetch_from(self.network())
             .await
-            .map_err(|error| {
-                if is_unknown_account(&error) {
-                    GatewayError::AccountNotFound(account_id)
-                } else {
-                    GatewayError::NearQuery(error.to_string())
-                }
-            })?;
+            .map_err(|error| account_query_error(account_id, &error))?;
         Ok(account.data)
     }
 
@@ -89,13 +124,7 @@ impl ReadNear for NearClient {
             .at(self.finality_policy().query_reference())
             .fetch_from(self.network())
             .await
-            .map_err(|error| {
-                if is_unknown_account(&error) {
-                    GatewayError::AccountNotFound(account_id)
-                } else {
-                    GatewayError::NearQuery(error.to_string())
-                }
-            })?;
+            .map_err(|error| account_query_error(account_id, &error))?;
         Ok(key.data)
     }
 
@@ -112,6 +141,26 @@ impl ReadNear for NearClient {
     }
 }
 
+fn account_query_error<E: std::fmt::Debug + std::fmt::Display>(
+    account_id: near_account_id::AccountId,
+    error: &E,
+) -> GatewayError {
+    if is_unknown_account(error) {
+        GatewayError::AccountNotFound(account_id)
+    } else {
+        GatewayError::NearQuery(error.to_string())
+    }
+}
+
+fn global_code_query_error<E: std::fmt::Debug + std::fmt::Display>(error: &E) -> GatewayError {
+    let message = error.to_string();
+    if is_no_global_contract_code(error) {
+        GatewayError::GlobalContractCodeNotFound(message)
+    } else {
+        GatewayError::NearQuery(message)
+    }
+}
+
 /// Whether a view error means the account does not exist (as opposed to a
 /// transient query failure). The node surfaces this inconsistently — sometimes
 /// as a typed `UnknownAccount` query error, sometimes as a plain message (see
@@ -120,6 +169,11 @@ impl ReadNear for NearClient {
 fn is_unknown_account<E: std::fmt::Debug>(error: &E) -> bool {
     let rendered = format!("{error:?}");
     rendered.contains("UnknownAccount") || rendered.contains("UNKNOWN_ACCOUNT")
+}
+
+fn is_no_global_contract_code<E: std::fmt::Debug>(error: &E) -> bool {
+    let rendered = format!("{error:?}");
+    rendered.contains("NoGlobalContractCode") || rendered.contains("NO_GLOBAL_CONTRACT_CODE")
 }
 
 /// Whether a transaction-status error means the chain has no record of the
@@ -133,7 +187,7 @@ pub(crate) fn is_unknown_transaction<E: std::fmt::Debug>(error: &E) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::is_unknown_account;
+    use super::{is_no_global_contract_code, is_unknown_account};
 
     // `&str`'s `Debug` renders its contents, standing in for a real error's
     // rendered form without constructing the deeply nested near-api error types.
@@ -149,6 +203,19 @@ mod tests {
         assert!(!is_unknown_account(&"TransportError(connection timed out)"));
         assert!(!is_unknown_account(
             &"ServerError(MethodNotFound { method_name: foo })"
+        ));
+    }
+
+    #[test]
+    fn detects_missing_global_code_in_both_error_forms() {
+        assert!(is_no_global_contract_code(
+            &"ServerError(NoGlobalContractCode)"
+        ));
+        assert!(is_no_global_contract_code(
+            &"handler error: NO_GLOBAL_CONTRACT_CODE"
+        ));
+        assert!(!is_no_global_contract_code(
+            &"TransportError(connection timed out)"
         ));
     }
 

--- a/gateway/methods-dispatch/Cargo.toml
+++ b/gateway/methods-dispatch/Cargo.toml
@@ -14,6 +14,7 @@ near-abi = "0.4.4"
 sha2.workspace = true
 templar-contract-artifacts = { workspace = true, features = ["fetch"] }
 wasmparser = { version = "0.244.0", default-features = false, features = ["std"] }
+tokio = { workspace = true, features = ["rt"] }
 zstd = "0.13.3"
 borsh.workspace = true
 near-account-id = { workspace = true, features = ["serde", "schemars"] }
@@ -34,6 +35,7 @@ templar-universal-account.workspace = true
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt"] }
+rstest.workspace = true
 
 [lints]
 workspace = true

--- a/gateway/methods-dispatch/Cargo.toml
+++ b/gateway/methods-dispatch/Cargo.toml
@@ -9,6 +9,12 @@ description = "NEAR dispatch implementations for Templar gateway method specific
 
 [dependencies]
 async-trait.workspace = true
+jsonschema = { version = "0.51.0", default-features = false }
+near-abi = "0.4.4"
+sha2.workspace = true
+templar-contract-artifacts = { workspace = true, features = ["fetch"] }
+wasmparser = { version = "0.244.0", default-features = false, features = ["std"] }
+zstd = "0.13.3"
 borsh.workspace = true
 near-account-id = { workspace = true, features = ["serde", "schemars"] }
 near-api.workspace = true

--- a/gateway/methods-dispatch/src/contract_abi.rs
+++ b/gateway/methods-dispatch/src/contract_abi.rs
@@ -8,12 +8,28 @@ use wasmparser::{Parser, Payload};
 const ZSTD_MAGIC: [u8; 4] = [0x28, 0xb5, 0x2f, 0xfd];
 const MAX_ABI_BYTES: u64 = 8 * 1024 * 1024;
 
-pub(crate) fn validate_constructor_args(wasm: &[u8], init_args: &[u8]) -> GatewayResult<()> {
-    let instance = serde_json::from_slice(init_args).map_err(|error| {
-        abi_error(format!(
-            "registry deployment init args are not JSON: {error}"
-        ))
-    })?;
+pub(crate) async fn validate_constructor_args(
+    wasm: Vec<u8>,
+    init_args: Vec<u8>,
+) -> GatewayResult<Vec<u8>> {
+    tokio::task::spawn_blocking(move || {
+        validate_constructor_args_sync(&wasm, &init_args)?;
+        Ok(init_args)
+    })
+    .await
+    .map_err(|error| GatewayError::Internal(format!("ABI validation task failed: {error}")))?
+}
+
+fn validate_constructor_args_sync(wasm: &[u8], init_args: &[u8]) -> GatewayResult<()> {
+    let instance = if init_args.is_empty() {
+        Value::Object(Map::new())
+    } else {
+        serde_json::from_slice(init_args).map_err(|error| {
+            abi_error(format!(
+                "registry deployment init args are not JSON: {error}"
+            ))
+        })?
+    };
     let schema = constructor_schema(wasm)?;
     let validator = jsonschema::draft7::new(&schema).map_err(|error| {
         abi_error(format!(
@@ -44,7 +60,11 @@ fn constructor_schema(wasm: &[u8]) -> GatewayResult<Value> {
     constructor_json_schema(&abi, constructor)
 }
 
+const MAX_ABI_CANDIDATES: usize = 16;
+
 fn extract_abi(wasm: &[u8]) -> GatewayResult<AbiRoot> {
+    let mut candidates = 0;
+    let mut first_error = None;
     for payload in Parser::new(0).parse_all(wasm) {
         let Payload::DataSection(section) = payload.map_err(|error| {
             abi_error(format!("registry deployment WASM is malformed: {error}"))
@@ -61,17 +81,42 @@ fn extract_abi(wasm: &[u8]) -> GatewayResult<AbiRoot> {
             })?;
 
             for offset in zstd_offsets(data.data) {
-                let Ok(decoded) = decompress(&data.data[offset..]) else {
-                    continue;
+                candidates += 1;
+                if candidates > MAX_ABI_CANDIDATES {
+                    return Err(abi_error(format!(
+                        "registry deployment WASM contains more than {MAX_ABI_CANDIDATES} embedded ABI candidates"
+                    )));
+                }
+
+                let decoded = match decompress(&data.data[offset..]) {
+                    Ok(decoded) => decoded,
+                    Err(error) => {
+                        first_error.get_or_insert_with(|| {
+                            format!(
+                                "registry deployment embedded ABI candidate cannot be decompressed: {error}"
+                            )
+                        });
+                        continue;
+                    }
                 };
-                if let Ok(abi) = serde_json::from_slice(&decoded) {
-                    return Ok(abi);
+                match serde_json::from_slice::<AbiRoot>(&decoded) {
+                    Ok(abi) => return Ok(abi),
+                    Err(error) => {
+                        first_error.get_or_insert_with(|| {
+                            format!(
+                                "registry deployment embedded ABI candidate is invalid: {error}"
+                            )
+                        });
+                    }
                 }
             }
         }
     }
 
-    Err(abi_error("registry deployment WASM has no embedded ABI"))
+    match first_error {
+        Some(error) => Err(abi_error(error)),
+        None => Err(abi_error("registry deployment WASM has no embedded ABI")),
+    }
 }
 
 fn zstd_offsets(data: &[u8]) -> impl Iterator<Item = usize> + '_ {
@@ -98,6 +143,11 @@ fn constructor_json_schema(abi: &AbiRoot, constructor: &AbiFunction) -> GatewayR
             "registry deployment constructor ABI does not use JSON parameters",
         ));
     };
+    let definitions = serde_json::to_value(&abi.body.root_schema.definitions).map_err(|error| {
+        abi_error(format!(
+            "registry deployment ABI definitions cannot be encoded as JSON Schema: {error}"
+        ))
+    })?;
 
     let mut properties = Map::new();
     let mut required = Vec::new();
@@ -107,7 +157,7 @@ fn constructor_json_schema(abi: &AbiRoot, constructor: &AbiFunction) -> GatewayR
                 "registry deployment constructor ABI cannot be encoded as JSON Schema: {error}"
             ))
         })?;
-        if !allows_null(&parameter_schema) {
+        if !parameter_is_optional(&parameter_schema, &definitions)? {
             required.push(Value::String(parameter.name.clone()));
         }
         properties.insert(parameter.name.clone(), parameter_schema);
@@ -121,14 +171,7 @@ fn constructor_json_schema(abi: &AbiRoot, constructor: &AbiFunction) -> GatewayR
         ("type".to_owned(), Value::String("object".to_owned())),
         ("properties".to_owned(), Value::Object(properties)),
         ("additionalProperties".to_owned(), Value::Bool(false)),
-        (
-            "definitions".to_owned(),
-            serde_json::to_value(&abi.body.root_schema.definitions).map_err(|error| {
-                abi_error(format!(
-                    "registry deployment ABI definitions cannot be encoded as JSON Schema: {error}"
-                ))
-            })?,
-        ),
+        ("definitions".to_owned(), definitions),
     ]);
     if !required.is_empty() {
         schema.insert("required".to_owned(), Value::Array(required));
@@ -137,42 +180,61 @@ fn constructor_json_schema(abi: &AbiRoot, constructor: &AbiFunction) -> GatewayR
     Ok(Value::Object(schema))
 }
 
-fn allows_null(schema: &Value) -> bool {
-    schema.get("nullable").and_then(Value::as_bool) == Some(true)
-        || schema.get("type").and_then(Value::as_str) == Some("null")
-        || ["anyOf", "oneOf"]
-            .into_iter()
-            .filter_map(|key| schema.get(key).and_then(Value::as_array))
-            .flatten()
-            .any(|schema| schema.get("type").and_then(Value::as_str) == Some("null"))
+fn parameter_is_optional(parameter_schema: &Value, definitions: &Value) -> GatewayResult<bool> {
+    if parameter_schema.get("default").is_some() {
+        return Ok(true);
+    }
+
+    let schema = Value::Object(Map::from_iter([
+        (
+            "$schema".to_owned(),
+            Value::String("http://json-schema.org/draft-07/schema#".to_owned()),
+        ),
+        ("definitions".to_owned(), definitions.clone()),
+        (
+            "allOf".to_owned(),
+            Value::Array(vec![parameter_schema.clone()]),
+        ),
+    ]));
+    let validator = jsonschema::draft7::new(&schema).map_err(|error| {
+        abi_error(format!(
+            "registry deployment constructor ABI contains an invalid JSON Schema: {error}"
+        ))
+    })?;
+    Ok(validator.is_valid(&Value::Null))
 }
 
 fn abi_error(reason: impl std::fmt::Display) -> GatewayError {
     GatewayError::RequestPreconditionFailed(format!(
-        "{reason}; pass --skip-abi-check to bypass ABI validation"
+        "{reason}; set skip_abi_check=true to bypass ABI validation"
     ))
 }
 
 #[cfg(test)]
 mod tests {
-    use super::validate_constructor_args;
+    use super::{validate_constructor_args_sync, MAX_ABI_CANDIDATES, ZSTD_MAGIC};
+    use rstest::rstest;
 
     fn wasm_with_abi(abi: &str) -> Vec<u8> {
         let compressed = zstd::stream::encode_all(abi.as_bytes(), 0).expect("compress ABI");
-        let mut section = vec![1, 0, 0x41, 0, 0x0b];
+        wasm_with_data(&compressed)
+    }
+
+    fn wasm_with_data(data: &[u8]) -> Vec<u8> {
+        let mut segment = vec![1, 0, 0x41, 0, 0x0b];
         push_uleb(
-            &mut section,
-            u32::try_from(compressed.len()).expect("compressed ABI fits Wasm section length"),
+            &mut segment,
+            u32::try_from(data.len()).expect("data fits Wasm segment length"),
         );
-        section.extend(compressed);
+        segment.extend(data);
 
         let mut wasm = b"\0asm\x01\0\0\0".to_vec();
         wasm.push(11);
         push_uleb(
             &mut wasm,
-            u32::try_from(section.len()).expect("Wasm section fits Wasm section length"),
+            u32::try_from(segment.len()).expect("Wasm section fits Wasm section length"),
         );
-        wasm.extend(section);
+        wasm.extend(segment);
         wasm
     }
 
@@ -190,48 +252,118 @@ mod tests {
         }
     }
 
+    fn valid_abi(args: &str) -> String {
+        r#"{"schema_version":"0.4.0","metadata":{},"body":{"functions":[{"name":"new","kind":"call","modifiers":["init"],"params":{"serialization_type":"json","args":__ARGS__}}],"root_schema":{"definitions":{}}}}"#
+            .replace("__ARGS__", args)
+    }
+
+    fn validate(wasm: &[u8], init_args: &[u8]) -> templar_gateway_core::GatewayResult<()> {
+        validate_constructor_args_sync(wasm, init_args)
+    }
+
     #[test]
     fn validates_constructor_args_against_embedded_abi() {
-        let wasm = wasm_with_abi(
-            r#"{"schema_version":"0.4.0","metadata":{},"body":{"functions":[{"name":"new","kind":"call","modifiers":["init"],"params":{"serialization_type":"json","args":[{"name":"owner_id","type_schema":{"type":"string"}}]}}],"root_schema":{"definitions":{}}}}"#,
-        );
+        let wasm = wasm_with_abi(&valid_abi(
+            r#"[{"name":"owner_id","type_schema":{"type":"string"}}]"#,
+        ));
 
-        validate_constructor_args(&wasm, br#"{"owner_id":"owner.near"}"#)
-            .expect("valid constructor arguments");
-        let error = validate_constructor_args(&wasm, br"{}")
-            .expect_err("missing required constructor argument");
-        assert!(error.to_string().contains("do not match"));
-        let error = validate_constructor_args(&wasm, br#"{"owner_id":3}"#)
-            .expect_err("wrong constructor argument type");
-        assert!(error.to_string().contains("do not match"));
-        let error = validate_constructor_args(&wasm, br#"{"owner_id":"owner.near","extra":true}"#)
-            .expect_err("unknown constructor argument");
+        validate(&wasm, br#"{"owner_id":"owner.near"}"#).expect("valid constructor arguments");
+    }
+
+    #[rstest]
+    #[case("{}", "missing required constructor argument")]
+    #[case(r#"{"owner_id":3}"#, "wrong constructor argument type")]
+    #[case(
+        r#"{"owner_id":"owner.near","extra":true}"#,
+        "unknown constructor argument"
+    )]
+    fn rejects_invalid_constructor_args(#[case] args: &str, #[case] reason: &str) {
+        let wasm = wasm_with_abi(&valid_abi(
+            r#"[{"name":"owner_id","type_schema":{"type":"string"}}]"#,
+        ));
+
+        let error = validate(&wasm, args.as_bytes()).expect_err(reason);
         assert!(error.to_string().contains("do not match"));
     }
 
     #[test]
-    fn preserves_abi_definitions_and_optional_parameters() {
-        let wasm = wasm_with_abi(
-            r##"{"schema_version":"0.4.0","metadata":{},"body":{"functions":[{"name":"new","kind":"call","modifiers":["init"],"params":{"serialization_type":"json","args":[{"name":"owner_id","type_schema":{"anyOf":[{"$ref":"#/definitions/Owner"},{"type":"null"}]}}]}}],"root_schema":{"definitions":{"Owner":{"type":"string"}}}}}"##,
-        );
+    fn accepts_empty_arguments_for_no_argument_constructor() {
+        let wasm = wasm_with_abi(&valid_abi("[]"));
 
-        validate_constructor_args(&wasm, br"{}").expect("optional constructor argument");
-        let error = validate_constructor_args(&wasm, br#"{"owner_id":7}"#)
-            .expect_err("definition-backed constructor argument type");
-        assert!(error.to_string().contains("do not match"));
+        validate(&wasm, b"").expect("empty arguments are the empty JSON object");
     }
 
     #[test]
-    fn rejects_missing_or_non_initializing_abi() {
-        let error = validate_constructor_args(b"\0asm\x01\0\0\0", br"{}")
-            .expect_err("missing embedded ABI");
-        assert!(error.to_string().contains("no embedded ABI"));
+    fn accepts_defaulted_and_nullable_parameters() {
+        let wasm = wasm_with_abi(
+            r##"{"schema_version":"0.4.0","metadata":{},"body":{"functions":[{"name":"new","kind":"call","modifiers":["init"],"params":{"serialization_type":"json","args":[{"name":"defaulted","type_schema":{"type":"string","default":"value"}},{"name":"nullable_type","type_schema":{"type":["string","null"]}},{"name":"nullable_ref","type_schema":{"$ref":"#/definitions/Nullable"}}]}}],"root_schema":{"definitions":{"Nullable":{"anyOf":[{"type":"string"},{"type":"null"}]}}}}}"##,
+        );
 
+        validate(&wasm, br"{}").expect("all optional parameters may be omitted");
+    }
+
+    #[test]
+    fn preserves_first_candidate_error_until_a_valid_candidate() {
+        let valid = zstd::stream::encode_all(valid_abi("[]").as_bytes(), 0).expect("compress ABI");
+        let mut data = ZSTD_MAGIC.to_vec();
+        data.extend([0, 1, 2]);
+        data.extend(valid);
+
+        validate(&wasm_with_data(&data), br"{}").expect("later valid candidate");
+    }
+
+    #[test]
+    fn preserves_malformed_candidate_diagnostic() {
+        let error = validate(&wasm_with_data(&ZSTD_MAGIC), br"{}")
+            .expect_err("malformed compressed candidate");
+
+        assert!(error
+            .to_string()
+            .contains("embedded ABI candidate cannot be decompressed"));
+    }
+
+    #[test]
+    fn preserves_invalid_abi_json_diagnostic() {
+        let invalid =
+            zstd::stream::encode_all(&b"not an ABI"[..], 0).expect("compress invalid ABI");
+
+        let error = validate(&wasm_with_data(&invalid), br"{}").expect_err("invalid ABI JSON");
+        assert!(error
+            .to_string()
+            .contains("embedded ABI candidate is invalid"));
+    }
+
+    #[test]
+    fn reports_no_abi_when_data_has_no_candidate() {
+        let error = validate(&wasm_with_data(b"not compressed"), br"{}").expect_err("no ABI");
+
+        assert!(error.to_string().contains("has no embedded ABI"));
+    }
+
+    #[test]
+    fn caps_embedded_abi_candidates() {
+        let data = ZSTD_MAGIC.repeat(MAX_ABI_CANDIDATES + 1);
+
+        let error = validate(&wasm_with_data(&data), br"{}").expect_err("candidate cap");
+        assert!(error
+            .to_string()
+            .contains("more than 16 embedded ABI candidates"));
+    }
+
+    #[test]
+    fn rejects_non_initializing_abi() {
         let wasm = wasm_with_abi(
             r#"{"schema_version":"0.4.0","metadata":{},"body":{"functions":[{"name":"new","kind":"call","modifiers":[],"params":{"serialization_type":"json","args":[]}}],"root_schema":{"definitions":{}}}}"#,
         );
-        let error =
-            validate_constructor_args(&wasm, br"{}").expect_err("non-initializing constructor");
+        let error = validate(&wasm, br"{}").expect_err("non-initializing constructor");
+
         assert!(error.to_string().contains("no initializing new method"));
+    }
+
+    #[test]
+    fn rejects_missing_embedded_abi() {
+        let error = validate(b"\0asm\x01\0\0\0", br"{}").expect_err("missing embedded ABI");
+
+        assert!(error.to_string().contains("no embedded ABI"));
     }
 }

--- a/gateway/methods-dispatch/src/contract_abi.rs
+++ b/gateway/methods-dispatch/src/contract_abi.rs
@@ -126,7 +126,7 @@ fn zstd_offsets(data: &[u8]) -> impl Iterator<Item = usize> + '_ {
 }
 
 fn decompress(compressed: &[u8]) -> std::io::Result<Vec<u8>> {
-    let zstd_decoder = zstd::stream::read::Decoder::new(Cursor::new(compressed))?;
+    let zstd_decoder = zstd::stream::read::Decoder::new(Cursor::new(compressed))?.single_frame();
     let mut decoded = Vec::new();
     zstd_decoder
         .take(MAX_ABI_BYTES + 1)
@@ -291,6 +291,15 @@ mod tests {
         let wasm = wasm_with_abi(&valid_abi("[]"));
 
         validate(&wasm, b"").expect("empty arguments are the empty JSON object");
+    }
+    #[test]
+    fn accepts_embedded_abi_before_trailing_segment_data() {
+        let mut data =
+            zstd::stream::encode_all(valid_abi("[]").as_bytes(), 0).expect("compress ABI");
+        data.extend(b"unrelated trailing Wasm data");
+
+        validate(&wasm_with_data(&data), br"{}")
+            .expect("trailing data after embedded ABI is ignored");
     }
 
     #[test]

--- a/gateway/methods-dispatch/src/contract_abi.rs
+++ b/gateway/methods-dispatch/src/contract_abi.rs
@@ -1,0 +1,237 @@
+use std::io::{Cursor, Read};
+
+use near_abi::{AbiFunction, AbiFunctionKind, AbiFunctionModifier, AbiParameters, AbiRoot};
+use serde_json::{Map, Value};
+use templar_gateway_core::{GatewayError, GatewayResult};
+use wasmparser::{Parser, Payload};
+
+const ZSTD_MAGIC: [u8; 4] = [0x28, 0xb5, 0x2f, 0xfd];
+const MAX_ABI_BYTES: u64 = 8 * 1024 * 1024;
+
+pub(crate) fn validate_constructor_args(wasm: &[u8], init_args: &[u8]) -> GatewayResult<()> {
+    let instance = serde_json::from_slice(init_args).map_err(|error| {
+        abi_error(format!(
+            "registry deployment init args are not JSON: {error}"
+        ))
+    })?;
+    let schema = constructor_schema(wasm)?;
+    let validator = jsonschema::draft7::new(&schema).map_err(|error| {
+        abi_error(format!(
+            "registry deployment constructor ABI contains an invalid JSON Schema: {error}"
+        ))
+    })?;
+
+    validator.validate(&instance).map_err(|error| {
+        abi_error(format!(
+            "registry deployment init args do not match the constructor ABI: {error}"
+        ))
+    })
+}
+
+fn constructor_schema(wasm: &[u8]) -> GatewayResult<Value> {
+    let abi = extract_abi(wasm)?;
+    let constructor = abi
+        .body
+        .functions
+        .iter()
+        .find(|function| {
+            function.name == "new"
+                && matches!(&function.kind, AbiFunctionKind::Call)
+                && function.modifiers.contains(&AbiFunctionModifier::Init)
+        })
+        .ok_or_else(|| abi_error("registry deployment ABI has no initializing new method"))?;
+
+    constructor_json_schema(&abi, constructor)
+}
+
+fn extract_abi(wasm: &[u8]) -> GatewayResult<AbiRoot> {
+    for payload in Parser::new(0).parse_all(wasm) {
+        let Payload::DataSection(section) = payload.map_err(|error| {
+            abi_error(format!("registry deployment WASM is malformed: {error}"))
+        })?
+        else {
+            continue;
+        };
+
+        for data in section {
+            let data = data.map_err(|error| {
+                abi_error(format!(
+                    "registry deployment WASM data section is malformed: {error}"
+                ))
+            })?;
+
+            for offset in zstd_offsets(data.data) {
+                let Ok(decoded) = decompress(&data.data[offset..]) else {
+                    continue;
+                };
+                if let Ok(abi) = serde_json::from_slice(&decoded) {
+                    return Ok(abi);
+                }
+            }
+        }
+    }
+
+    Err(abi_error("registry deployment WASM has no embedded ABI"))
+}
+
+fn zstd_offsets(data: &[u8]) -> impl Iterator<Item = usize> + '_ {
+    data.windows(ZSTD_MAGIC.len())
+        .enumerate()
+        .filter_map(|(offset, window)| (window == ZSTD_MAGIC).then_some(offset))
+}
+
+fn decompress(compressed: &[u8]) -> std::io::Result<Vec<u8>> {
+    let zstd_decoder = zstd::stream::read::Decoder::new(Cursor::new(compressed))?;
+    let mut decoded = Vec::new();
+    zstd_decoder
+        .take(MAX_ABI_BYTES + 1)
+        .read_to_end(&mut decoded)?;
+    if decoded.len() as u64 > MAX_ABI_BYTES {
+        return Err(std::io::Error::other("embedded ABI exceeds maximum size"));
+    }
+    Ok(decoded)
+}
+
+fn constructor_json_schema(abi: &AbiRoot, constructor: &AbiFunction) -> GatewayResult<Value> {
+    let AbiParameters::Json { args } = &constructor.params else {
+        return Err(abi_error(
+            "registry deployment constructor ABI does not use JSON parameters",
+        ));
+    };
+
+    let mut properties = Map::new();
+    let mut required = Vec::new();
+    for parameter in args {
+        let parameter_schema = serde_json::to_value(&parameter.type_schema).map_err(|error| {
+            abi_error(format!(
+                "registry deployment constructor ABI cannot be encoded as JSON Schema: {error}"
+            ))
+        })?;
+        if !allows_null(&parameter_schema) {
+            required.push(Value::String(parameter.name.clone()));
+        }
+        properties.insert(parameter.name.clone(), parameter_schema);
+    }
+
+    let mut schema = Map::from_iter([
+        (
+            "$schema".to_owned(),
+            Value::String("http://json-schema.org/draft-07/schema#".to_owned()),
+        ),
+        ("type".to_owned(), Value::String("object".to_owned())),
+        ("properties".to_owned(), Value::Object(properties)),
+        ("additionalProperties".to_owned(), Value::Bool(false)),
+        (
+            "definitions".to_owned(),
+            serde_json::to_value(&abi.body.root_schema.definitions).map_err(|error| {
+                abi_error(format!(
+                    "registry deployment ABI definitions cannot be encoded as JSON Schema: {error}"
+                ))
+            })?,
+        ),
+    ]);
+    if !required.is_empty() {
+        schema.insert("required".to_owned(), Value::Array(required));
+    }
+
+    Ok(Value::Object(schema))
+}
+
+fn allows_null(schema: &Value) -> bool {
+    schema.get("nullable").and_then(Value::as_bool) == Some(true)
+        || schema.get("type").and_then(Value::as_str) == Some("null")
+        || ["anyOf", "oneOf"]
+            .into_iter()
+            .filter_map(|key| schema.get(key).and_then(Value::as_array))
+            .flatten()
+            .any(|schema| schema.get("type").and_then(Value::as_str) == Some("null"))
+}
+
+fn abi_error(reason: impl std::fmt::Display) -> GatewayError {
+    GatewayError::RequestPreconditionFailed(format!(
+        "{reason}; pass --skip-abi-check to bypass ABI validation"
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_constructor_args;
+
+    fn wasm_with_abi(abi: &str) -> Vec<u8> {
+        let compressed = zstd::stream::encode_all(abi.as_bytes(), 0).expect("compress ABI");
+        let mut section = vec![1, 0, 0x41, 0, 0x0b];
+        push_uleb(
+            &mut section,
+            u32::try_from(compressed.len()).expect("compressed ABI fits Wasm section length"),
+        );
+        section.extend(compressed);
+
+        let mut wasm = b"\0asm\x01\0\0\0".to_vec();
+        wasm.push(11);
+        push_uleb(
+            &mut wasm,
+            u32::try_from(section.len()).expect("Wasm section fits Wasm section length"),
+        );
+        wasm.extend(section);
+        wasm
+    }
+
+    fn push_uleb(bytes: &mut Vec<u8>, mut value: u32) {
+        loop {
+            let mut byte = (value & 0x7f) as u8;
+            value >>= 7;
+            if value != 0 {
+                byte |= 0x80;
+            }
+            bytes.push(byte);
+            if value == 0 {
+                return;
+            }
+        }
+    }
+
+    #[test]
+    fn validates_constructor_args_against_embedded_abi() {
+        let wasm = wasm_with_abi(
+            r#"{"schema_version":"0.4.0","metadata":{},"body":{"functions":[{"name":"new","kind":"call","modifiers":["init"],"params":{"serialization_type":"json","args":[{"name":"owner_id","type_schema":{"type":"string"}}]}}],"root_schema":{"definitions":{}}}}"#,
+        );
+
+        validate_constructor_args(&wasm, br#"{"owner_id":"owner.near"}"#)
+            .expect("valid constructor arguments");
+        let error = validate_constructor_args(&wasm, br"{}")
+            .expect_err("missing required constructor argument");
+        assert!(error.to_string().contains("do not match"));
+        let error = validate_constructor_args(&wasm, br#"{"owner_id":3}"#)
+            .expect_err("wrong constructor argument type");
+        assert!(error.to_string().contains("do not match"));
+        let error = validate_constructor_args(&wasm, br#"{"owner_id":"owner.near","extra":true}"#)
+            .expect_err("unknown constructor argument");
+        assert!(error.to_string().contains("do not match"));
+    }
+
+    #[test]
+    fn preserves_abi_definitions_and_optional_parameters() {
+        let wasm = wasm_with_abi(
+            r##"{"schema_version":"0.4.0","metadata":{},"body":{"functions":[{"name":"new","kind":"call","modifiers":["init"],"params":{"serialization_type":"json","args":[{"name":"owner_id","type_schema":{"anyOf":[{"$ref":"#/definitions/Owner"},{"type":"null"}]}}]}}],"root_schema":{"definitions":{"Owner":{"type":"string"}}}}}"##,
+        );
+
+        validate_constructor_args(&wasm, br"{}").expect("optional constructor argument");
+        let error = validate_constructor_args(&wasm, br#"{"owner_id":7}"#)
+            .expect_err("definition-backed constructor argument type");
+        assert!(error.to_string().contains("do not match"));
+    }
+
+    #[test]
+    fn rejects_missing_or_non_initializing_abi() {
+        let error = validate_constructor_args(b"\0asm\x01\0\0\0", br"{}")
+            .expect_err("missing embedded ABI");
+        assert!(error.to_string().contains("no embedded ABI"));
+
+        let wasm = wasm_with_abi(
+            r#"{"schema_version":"0.4.0","metadata":{},"body":{"functions":[{"name":"new","kind":"call","modifiers":[],"params":{"serialization_type":"json","args":[]}}],"root_schema":{"definitions":{}}}}"#,
+        );
+        let error =
+            validate_constructor_args(&wasm, br"{}").expect_err("non-initializing constructor");
+        assert!(error.to_string().contains("no initializing new method"));
+    }
+}

--- a/gateway/methods-dispatch/src/lib.rs
+++ b/gateway/methods-dispatch/src/lib.rs
@@ -1,5 +1,6 @@
 mod account_impl;
 mod chain_impl;
+mod contract_abi;
 mod contract_impl;
 mod ft_impl;
 mod intents_impl;
@@ -15,6 +16,7 @@ mod pyth_impl;
 mod redstone_impl;
 mod ref_finance_impl;
 mod registry_impl;
+mod registry_wasm;
 mod storage_impl;
 #[cfg(test)]
 mod test_ctx;

--- a/gateway/methods-dispatch/src/registry_impl.rs
+++ b/gateway/methods-dispatch/src/registry_impl.rs
@@ -10,7 +10,9 @@ use templar_gateway_core::{
 use templar_gateway_methods_spec::registry;
 use templar_gateway_types::RegistryVersion;
 
-use crate::Dispatch;
+use crate::{
+    contract_abi::validate_constructor_args, registry_wasm::resolve_registry_wasm, Dispatch,
+};
 
 #[async_trait]
 impl<C> DispatchRead<registry::ListDeployments, C> for Dispatch
@@ -212,6 +214,17 @@ pub(crate) async fn plan_create_from_registry<C: HasNearClient>(
         .contract(target.registry_id.clone())
         .cached_version()
         .await?;
+    if !target.skip_abi_check {
+        let wasm = resolve_registry_wasm(
+            ctx,
+            &target.registry_id,
+            registry_version,
+            &target.version_key,
+        )
+        .await?;
+        validate_constructor_args(&wasm, &init_args)?;
+    }
+
     Ok(OperationPlan::single(
         ctx.near_client().registry(target.registry_id).deploy(
             ContractWriteOptions::new(signer_account_id)

--- a/gateway/methods-dispatch/src/registry_impl.rs
+++ b/gateway/methods-dispatch/src/registry_impl.rs
@@ -207,7 +207,7 @@ pub(crate) async fn plan_create_from_registry<C: HasNearClient>(
     ctx: &C,
     signer_account_id: templar_gateway_types::ManagedAccountId,
     target: registry::DeployTarget,
-    init_args: Vec<u8>,
+    mut init_args: Vec<u8>,
 ) -> GatewayResult<OperationPlan> {
     let registry_version = ctx
         .near_client()
@@ -222,7 +222,7 @@ pub(crate) async fn plan_create_from_registry<C: HasNearClient>(
             &target.version_key,
         )
         .await?;
-        validate_constructor_args(&wasm, &init_args)?;
+        init_args = validate_constructor_args(wasm, init_args).await?;
     }
 
     Ok(OperationPlan::single(

--- a/gateway/methods-dispatch/src/registry_wasm.rs
+++ b/gateway/methods-dispatch/src/registry_wasm.rs
@@ -1,0 +1,263 @@
+use near_account_id::AccountId;
+use near_api::types::CryptoHash;
+use sha2::{Digest, Sha256};
+use templar_common::registry::VersionAvailability;
+use templar_contract_artifacts::fetch;
+use templar_gateway_core::{
+    client::registry::{GetVersionArgs, GetVersionCodeChunkArgs},
+    GatewayError, GatewayResult, HasNearClient, ReadNear,
+};
+use templar_gateway_types::RegistryVersion;
+
+const CODE_CHUNK_LEN: u32 = 64 * 1024;
+const MAX_STORED_CODE_LEN: u32 = 4 * 1024 * 1024;
+
+#[derive(Debug, PartialEq, Eq)]
+enum OnchainCodeSource {
+    Global,
+    Stored(StoredCodeLen),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct StoredCodeLen(u32);
+
+pub(crate) async fn resolve_registry_wasm<C: HasNearClient>(
+    ctx: &C,
+    registry_id: &AccountId,
+    registry_version: RegistryVersion,
+    version_key: &str,
+) -> GatewayResult<Vec<u8>> {
+    let client = ctx.near_client().registry(registry_id.clone());
+
+    if !registry_version.supports_entry_and_version_views() {
+        return resolve_legacy_registry_wasm(ctx, &client, version_key).await;
+    }
+
+    let Some(version) = client
+        .get_version(GetVersionArgs {
+            version_key: version_key.to_owned(),
+        })
+        .await?
+    else {
+        return Err(precondition(format!(
+            "registry version {version_key} does not exist"
+        )));
+    };
+
+    let source = onchain_code_source(version_key, version.availability)?;
+    let hash = CryptoHash(version.code_hash.into());
+
+    resolve_available_version(
+        ctx,
+        &client,
+        version_key,
+        source,
+        hash,
+        catalogued_code(hash.0).await,
+    )
+    .await
+}
+
+fn onchain_code_source(
+    version_key: &str,
+    availability: VersionAvailability,
+) -> GatewayResult<OnchainCodeSource> {
+    match availability {
+        VersionAvailability::Global => Ok(OnchainCodeSource::Global),
+        VersionAvailability::Stored { code_len } if code_len <= MAX_STORED_CODE_LEN => {
+            Ok(OnchainCodeSource::Stored(StoredCodeLen(code_len)))
+        }
+        VersionAvailability::Stored { .. } => Err(precondition(format!(
+            "registry version {version_key} reports code larger than {MAX_STORED_CODE_LEN} bytes"
+        ))),
+        VersionAvailability::Removed => Err(precondition(format!(
+            "registry version {version_key} has been removed and cannot be deployed"
+        ))),
+    }
+}
+
+async fn resolve_available_version<C: HasNearClient>(
+    ctx: &C,
+    client: &templar_gateway_core::client::registry::RegistryClient<'_>,
+    version_key: &str,
+    source: OnchainCodeSource,
+    hash: CryptoHash,
+    catalogued: Option<Vec<u8>>,
+) -> GatewayResult<Vec<u8>> {
+    if let Some(code) = catalogued {
+        return Ok(code);
+    }
+
+    let code = match source {
+        OnchainCodeSource::Global => ctx.near_client().view_global_contract_code(hash).await?,
+        OnchainCodeSource::Stored(code_len) => {
+            read_stored_code(client, version_key, code_len).await?
+        }
+    };
+
+    verify_code_hash(code, hash)
+}
+
+async fn resolve_legacy_registry_wasm<C: HasNearClient>(
+    ctx: &C,
+    client: &templar_gateway_core::client::registry::RegistryClient<'_>,
+    version_key: &str,
+) -> GatewayResult<Vec<u8>> {
+    let Some(hash) = client
+        .get_version_code_hash(GetVersionArgs {
+            version_key: version_key.to_owned(),
+        })
+        .await?
+    else {
+        return Err(precondition(format!(
+            "registry version {version_key} does not exist"
+        )));
+    };
+
+    let hash = CryptoHash(hash.into());
+
+    let code = ctx
+        .near_client()
+        .view_global_contract_code(hash)
+        .await
+        .map_err(|error| match error {
+            GatewayError::GlobalContractCodeNotFound(_) => precondition(format!(
+                "registry version {version_key} is not global and this registry cannot expose stored code; upgrade the registry before deployment"
+            )),
+            other => other,
+        })?;
+
+    verify_code_hash(code, hash)
+}
+
+async fn catalogued_code(hash: [u8; 32]) -> Option<Vec<u8>> {
+    fetch::released_bytes_by_sha256(&hash).await.ok()
+}
+
+async fn read_stored_code(
+    client: &templar_gateway_core::client::registry::RegistryClient<'_>,
+    version_key: &str,
+    code_len: StoredCodeLen,
+) -> GatewayResult<Vec<u8>> {
+    let mut code = Vec::with_capacity(code_len.0 as usize);
+    let mut request = GetVersionCodeChunkArgs {
+        version_key: version_key.to_owned(),
+        offset: 0,
+        len: 0,
+    };
+
+    while request.offset < code_len.0 {
+        request.len = (code_len.0 - request.offset).min(CODE_CHUNK_LEN);
+        let Some(chunk) = client.get_version_code_chunk(&request).await? else {
+            return Err(precondition(format!(
+                "registry version {version_key} no longer has stored code"
+            )));
+        };
+
+        if chunk.is_empty() || chunk.len() > request.len as usize {
+            return Err(precondition(format!(
+                "registry version {version_key} returned an invalid code chunk"
+            )));
+        }
+
+        request.offset += u32::try_from(chunk.len()).map_err(|_| {
+            precondition(format!(
+                "registry version {version_key} returned an invalid code chunk"
+            ))
+        })?;
+        code.extend(chunk);
+    }
+
+    Ok(code)
+}
+
+fn verify_code_hash(code: Vec<u8>, expected: CryptoHash) -> GatewayResult<Vec<u8>> {
+    let actual = CryptoHash(Sha256::digest(&code).into());
+    if actual != expected {
+        return Err(precondition(format!(
+            "resolved registry code hash {actual} does not match expected {expected}"
+        )));
+    }
+
+    Ok(code)
+}
+
+fn precondition(message: String) -> GatewayError {
+    GatewayError::RequestPreconditionFailed(message)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        onchain_code_source, resolve_available_version, verify_code_hash, CryptoHash,
+        OnchainCodeSource, Sha256, StoredCodeLen, MAX_STORED_CODE_LEN,
+    };
+    use crate::test_ctx::offline_ctx;
+    use sha2::Digest;
+    use templar_common::registry::VersionAvailability;
+    use templar_gateway_core::{GatewayError, HasNearClient};
+
+    #[test]
+    fn rejects_resolved_code_with_a_different_hash() {
+        let error =
+            verify_code_hash(vec![1, 2, 3], CryptoHash([0; 32])).expect_err("mismatched code hash");
+
+        assert!(error.to_string().contains("does not match"));
+    }
+
+    #[test]
+    fn rejects_an_oversized_stored_code_advertisement() {
+        let error = onchain_code_source(
+            "oversized@1.0.0",
+            VersionAvailability::Stored {
+                code_len: MAX_STORED_CODE_LEN + 1,
+            },
+        )
+        .expect_err("stored code must respect the registry storage limit");
+
+        assert!(error.to_string().contains("reports code larger"));
+    }
+
+    #[tokio::test]
+    async fn catalogued_normal_code_skips_the_chunk_query() {
+        let ctx = offline_ctx();
+        let code = vec![1, 2, 3];
+        let hash = CryptoHash(Sha256::digest(&code).into());
+        let client = ctx
+            .near_client()
+            .registry("registry.near".parse().expect("valid account ID"));
+
+        let resolved = resolve_available_version(
+            &ctx,
+            &client,
+            "catalogued@1.0.0",
+            OnchainCodeSource::Stored(StoredCodeLen(300)),
+            hash,
+            Some(code.clone()),
+        )
+        .await
+        .expect("catalogued code must not use the unreachable chunk query");
+
+        assert_eq!(resolved, code);
+    }
+
+    #[tokio::test]
+    async fn unavailable_catalog_uses_the_onchain_source() {
+        let ctx = offline_ctx();
+        let client = ctx
+            .near_client()
+            .registry("registry.near".parse().expect("valid account ID"));
+        let error = resolve_available_version(
+            &ctx,
+            &client,
+            "uncatalogued@1.0.0",
+            OnchainCodeSource::Stored(StoredCodeLen(1)),
+            CryptoHash([0; 32]),
+            None,
+        )
+        .await
+        .expect_err("an unavailable catalog must continue to the onchain source");
+
+        assert!(matches!(error, GatewayError::NearQuery(_)));
+    }
+}

--- a/gateway/methods-dispatch/src/registry_wasm.rs
+++ b/gateway/methods-dispatch/src/registry_wasm.rs
@@ -78,7 +78,7 @@ impl StoredCodeAssembler {
             .checked_sub(self.offset)
             .ok_or_else(invalid)?;
         if chunk_len == 0
-            || chunk_len > requested_len
+            || chunk_len != requested_len
             || requested_len > remaining
             || self
                 .offset
@@ -334,11 +334,12 @@ mod tests {
     }
 
     #[test]
-    fn rejects_missing_empty_oversized_and_overrun_chunks_without_progress() {
+    fn rejects_missing_empty_partial_oversized_and_overrun_chunks_without_progress() {
         let mut assembler = StoredCodeAssembler::new(stored_len(3));
         for (requested_len, chunk) in [
             (3, None),
             (3, Some(Vec::new())),
+            (3, Some(vec![1])),
             (2, Some(vec![1, 2, 3])),
             (4, Some(vec![1, 2, 3])),
         ] {

--- a/gateway/methods-dispatch/src/registry_wasm.rs
+++ b/gateway/methods-dispatch/src/registry_wasm.rs
@@ -19,7 +19,89 @@ enum OnchainCodeSource {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-struct StoredCodeLen(u32);
+struct StoredCodeLen {
+    value: u32,
+}
+
+impl TryFrom<u32> for StoredCodeLen {
+    type Error = ();
+
+    fn try_from(value: u32) -> Result<Self, Self::Error> {
+        (value <= MAX_STORED_CODE_LEN)
+            .then_some(Self { value })
+            .ok_or(())
+    }
+}
+
+impl StoredCodeLen {
+    fn value(self) -> u32 {
+        self.value
+    }
+}
+
+struct StoredCodeAssembler {
+    expected_len: StoredCodeLen,
+    offset: u32,
+    bytes: Vec<u8>,
+}
+
+impl StoredCodeAssembler {
+    fn new(expected_len: StoredCodeLen) -> Self {
+        Self {
+            expected_len,
+            offset: 0,
+            bytes: Vec::with_capacity(expected_len.value() as usize),
+        }
+    }
+
+    fn next_len(&self) -> Option<u32> {
+        (self.offset < self.expected_len.value())
+            .then(|| (self.expected_len.value() - self.offset).min(CODE_CHUNK_LEN))
+    }
+
+    fn push(
+        &mut self,
+        version_key: &str,
+        requested_len: u32,
+        chunk: Option<Vec<u8>>,
+    ) -> GatewayResult<()> {
+        let invalid = || {
+            precondition(format!(
+                "registry version {version_key} returned an invalid code chunk"
+            ))
+        };
+        let chunk = chunk.ok_or_else(invalid)?;
+        let chunk_len = u32::try_from(chunk.len()).map_err(|_| invalid())?;
+        let remaining = self
+            .expected_len
+            .value()
+            .checked_sub(self.offset)
+            .ok_or_else(invalid)?;
+        if chunk_len == 0
+            || chunk_len > requested_len
+            || requested_len > remaining
+            || self
+                .offset
+                .checked_add(chunk_len)
+                .is_none_or(|end| end > self.expected_len.value())
+        {
+            return Err(invalid());
+        }
+
+        self.offset += chunk_len;
+        self.bytes.extend(chunk);
+        Ok(())
+    }
+
+    fn finish(self) -> GatewayResult<Vec<u8>> {
+        if self.next_len().is_some() {
+            return Err(precondition(
+                "stored code assembly ended before the advertised length".to_owned(),
+            ));
+        }
+        Ok(self.bytes)
+    }
+}
 
 pub(crate) async fn resolve_registry_wasm<C: HasNearClient>(
     ctx: &C,
@@ -64,12 +146,14 @@ fn onchain_code_source(
 ) -> GatewayResult<OnchainCodeSource> {
     match availability {
         VersionAvailability::Global => Ok(OnchainCodeSource::Global),
-        VersionAvailability::Stored { code_len } if code_len <= MAX_STORED_CODE_LEN => {
-            Ok(OnchainCodeSource::Stored(StoredCodeLen(code_len)))
+        VersionAvailability::Stored { code_len } => {
+            let code_len = StoredCodeLen::try_from(code_len).map_err(|()| {
+                precondition(format!(
+                    "registry version {version_key} reports code larger than {MAX_STORED_CODE_LEN} bytes"
+                ))
+            })?;
+            Ok(OnchainCodeSource::Stored(code_len))
         }
-        VersionAvailability::Stored { .. } => Err(precondition(format!(
-            "registry version {version_key} reports code larger than {MAX_STORED_CODE_LEN} bytes"
-        ))),
         VersionAvailability::Removed => Err(precondition(format!(
             "registry version {version_key} has been removed and cannot be deployed"
         ))),
@@ -113,21 +197,23 @@ async fn resolve_legacy_registry_wasm<C: HasNearClient>(
             "registry version {version_key} does not exist"
         )));
     };
-
     let hash = CryptoHash(hash.into());
 
-    let code = ctx
-        .near_client()
-        .view_global_contract_code(hash)
-        .await
-        .map_err(|error| match error {
-            GatewayError::GlobalContractCodeNotFound(_) => precondition(format!(
-                "registry version {version_key} is not global and this registry cannot expose stored code; upgrade the registry before deployment"
-            )),
-            other => other,
-        })?;
-
-    verify_code_hash(code, hash)
+    resolve_available_version(
+        ctx,
+        client,
+        version_key,
+        OnchainCodeSource::Global,
+        hash,
+        catalogued_code(hash.0).await,
+    )
+    .await
+    .map_err(|error| match error {
+        GatewayError::GlobalContractCodeNotFound(_) => precondition(format!(
+            "registry version {version_key} is not global and this registry cannot expose stored code; upgrade the registry before deployment"
+        )),
+        other => other,
+    })
 }
 
 async fn catalogued_code(hash: [u8; 32]) -> Option<Vec<u8>> {
@@ -139,36 +225,23 @@ async fn read_stored_code(
     version_key: &str,
     code_len: StoredCodeLen,
 ) -> GatewayResult<Vec<u8>> {
-    let mut code = Vec::with_capacity(code_len.0 as usize);
-    let mut request = GetVersionCodeChunkArgs {
-        version_key: version_key.to_owned(),
-        offset: 0,
-        len: 0,
-    };
-
-    while request.offset < code_len.0 {
-        request.len = (code_len.0 - request.offset).min(CODE_CHUNK_LEN);
-        let Some(chunk) = client.get_version_code_chunk(&request).await? else {
+    let mut assembler = StoredCodeAssembler::new(code_len);
+    while let Some(len) = assembler.next_len() {
+        let request = GetVersionCodeChunkArgs {
+            version_key: version_key.to_owned(),
+            offset: assembler.offset,
+            len,
+        };
+        let chunk = client.get_version_code_chunk(&request).await?;
+        if chunk.is_none() {
             return Err(precondition(format!(
                 "registry version {version_key} no longer has stored code"
             )));
-        };
-
-        if chunk.is_empty() || chunk.len() > request.len as usize {
-            return Err(precondition(format!(
-                "registry version {version_key} returned an invalid code chunk"
-            )));
         }
-
-        request.offset += u32::try_from(chunk.len()).map_err(|_| {
-            precondition(format!(
-                "registry version {version_key} returned an invalid code chunk"
-            ))
-        })?;
-        code.extend(chunk);
+        assembler.push(version_key, len, chunk)?;
     }
 
-    Ok(code)
+    assembler.finish()
 }
 
 fn verify_code_hash(code: Vec<u8>, expected: CryptoHash) -> GatewayResult<Vec<u8>> {
@@ -190,12 +263,23 @@ fn precondition(message: String) -> GatewayError {
 mod tests {
     use super::{
         onchain_code_source, resolve_available_version, verify_code_hash, CryptoHash,
-        OnchainCodeSource, Sha256, StoredCodeLen, MAX_STORED_CODE_LEN,
+        OnchainCodeSource, Sha256, StoredCodeAssembler, StoredCodeLen, CODE_CHUNK_LEN,
+        MAX_STORED_CODE_LEN,
     };
     use crate::test_ctx::offline_ctx;
     use sha2::Digest;
     use templar_common::registry::VersionAvailability;
     use templar_gateway_core::{GatewayError, HasNearClient};
+
+    fn stored_len(value: u32) -> StoredCodeLen {
+        StoredCodeLen::try_from(value).expect("valid stored code length")
+    }
+
+    #[test]
+    fn accepts_maximum_stored_code_length_and_rejects_the_next_value() {
+        assert!(StoredCodeLen::try_from(MAX_STORED_CODE_LEN).is_ok());
+        assert!(StoredCodeLen::try_from(MAX_STORED_CODE_LEN + 1).is_err());
+    }
 
     #[test]
     fn rejects_resolved_code_with_a_different_hash() {
@@ -218,8 +302,55 @@ mod tests {
         assert!(error.to_string().contains("reports code larger"));
     }
 
+    #[test]
+    fn assembles_chunks_with_bounded_progression() {
+        let mut assembler = StoredCodeAssembler::new(stored_len(CODE_CHUNK_LEN + 3));
+        assert_eq!(assembler.next_len(), Some(CODE_CHUNK_LEN));
+        assembler
+            .push(
+                "registry.near",
+                CODE_CHUNK_LEN,
+                Some(vec![1; CODE_CHUNK_LEN as usize]),
+            )
+            .expect("first chunk");
+        assert_eq!(assembler.next_len(), Some(3));
+        assembler
+            .push("registry.near", 3, Some(vec![2; 3]))
+            .expect("final chunk");
+        assert_eq!(assembler.next_len(), None);
+    }
+    #[test]
+    fn finishes_after_final_chunk() {
+        let mut assembler = StoredCodeAssembler::new(stored_len(3));
+        assembler
+            .push("registry.near", 3, Some(vec![1, 2, 3]))
+            .expect("final chunk");
+
+        assert_eq!(assembler.next_len(), None);
+        assert_eq!(
+            assembler.finish().expect("complete assembly"),
+            vec![1, 2, 3]
+        );
+    }
+
+    #[test]
+    fn rejects_missing_empty_oversized_and_overrun_chunks_without_progress() {
+        let mut assembler = StoredCodeAssembler::new(stored_len(3));
+        for (requested_len, chunk) in [
+            (3, None),
+            (3, Some(Vec::new())),
+            (2, Some(vec![1, 2, 3])),
+            (4, Some(vec![1, 2, 3])),
+        ] {
+            assembler
+                .push("registry.near", requested_len, chunk)
+                .expect_err("malformed chunk");
+            assert_eq!(assembler.next_len(), Some(3));
+        }
+    }
+
     #[tokio::test]
-    async fn catalogued_normal_code_skips_the_chunk_query() {
+    async fn catalogued_code_skips_both_onchain_sources() {
         let ctx = offline_ctx();
         let code = vec![1, 2, 3];
         let hash = CryptoHash(Sha256::digest(&code).into());
@@ -227,18 +358,29 @@ mod tests {
             .near_client()
             .registry("registry.near".parse().expect("valid account ID"));
 
-        let resolved = resolve_available_version(
+        let stored = resolve_available_version(
             &ctx,
             &client,
             "catalogued@1.0.0",
-            OnchainCodeSource::Stored(StoredCodeLen(300)),
+            OnchainCodeSource::Stored(stored_len(300)),
             hash,
             Some(code.clone()),
         )
         .await
-        .expect("catalogued code must not use the unreachable chunk query");
+        .expect("catalogued stored code must not query the chain");
+        let global = resolve_available_version(
+            &ctx,
+            &client,
+            "catalogued@1.0.0",
+            OnchainCodeSource::Global,
+            hash,
+            Some(code.clone()),
+        )
+        .await
+        .expect("catalogued global code must not query the chain");
 
-        assert_eq!(resolved, code);
+        assert_eq!(stored, code);
+        assert_eq!(global, code);
     }
 
     #[tokio::test]
@@ -251,7 +393,7 @@ mod tests {
             &ctx,
             &client,
             "uncatalogued@1.0.0",
-            OnchainCodeSource::Stored(StoredCodeLen(1)),
+            OnchainCodeSource::Stored(stored_len(1)),
             CryptoHash([0; 32]),
             None,
         )

--- a/gateway/methods-spec/src/proxy_oracle.rs
+++ b/gateway/methods-spec/src/proxy_oracle.rs
@@ -9,9 +9,8 @@ use templar_proxy_oracle_near_common::input::Source;
 /// Create a proxy oracle from the registry.
 ///
 /// `owner_id` seats the owner at init; omitting it leaves the registry as owner.
-/// Only a version whose `new` accepts one honors it, and the version is not
-/// checked here — see
-/// [`ProxyOracleVersion::new_accepts_owner_id`](templar_gateway_types::version::ProxyOracleVersion::new_accepts_owner_id).
+/// Constructor ABI validation normally rejects a target that cannot honor it.
+/// `skip_abi_check` disables that protection and can leave the registry as owner.
 #[derive(MethodSpec, Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[method(write = "proxyOracle.create")]
 pub struct Create {

--- a/gateway/methods-spec/src/redstone.rs
+++ b/gateway/methods-spec/src/redstone.rs
@@ -7,10 +7,9 @@ use templar_gateway_types::Base64Bytes;
 
 /// Create a RedStone price adapter from the registry.
 ///
-/// `admin_id` seats the adapter's administration roles at init. Only a version
-/// whose `new` takes one honors it, and the version is not checked here — a
-/// pre-`0.2.0` adapter ignores it and leaves the deploying registry as admin. See
-/// [`RedstoneAdapterVersion::new_requires_admin_id`](templar_gateway_types::version::RedstoneAdapterVersion::new_requires_admin_id).
+/// `admin_id` seats the adapter's administration roles at init. Registry
+/// deployment normally validates the target constructor ABI before it plans the
+/// transaction; `skip_abi_check` disables that protection.
 #[derive(MethodSpec, Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[method(write = "redstone.create")]
 pub struct Create {

--- a/gateway/methods-spec/src/registry.rs
+++ b/gateway/methods-spec/src/registry.rs
@@ -105,20 +105,24 @@ pub struct AddVersion {
 /// stay at the top level of the wire JSON.
 ///
 /// A contract this codebase models gets its own `<namespace>.create` declaring only
-/// its init fields beside this, dispatched through `plan_create_from_registry`. One
-/// it does not model goes through [`Deploy`] with opaque `init_args`.
+/// its init fields beside this, dispatched through `plan_create_from_registry`.
+/// Unmodeled contracts use [`Deploy`]; its JSON init args are validated against the
+/// target constructor ABI unless `skip_abi_check` is set.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct DeployTarget {
     pub registry_id: AccountId,
     pub name: String,
     pub version_key: String,
+    /// Skip embedded-ABI validation for a deployment whose constructor cannot be checked.
+    #[serde(default)]
+    pub skip_abi_check: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub full_access_keys: Option<Vec<PublicKey>>,
     pub deposit: NearToken,
 }
 
-/// Deploy a contract from a registry version, with init args the gateway does not
-/// interpret.
+/// Deploy a contract from a registry version with JSON init args validated against
+/// the target constructor ABI unless `skip_abi_check` is set.
 #[derive(MethodSpec, Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[method(write = "registry.deploy")]
 pub struct Deploy {

--- a/gateway/methods-spec/src/registry.rs
+++ b/gateway/methods-spec/src/registry.rs
@@ -6,6 +6,9 @@ use templar_gateway_types::{
     common::Pagination, contract::ContractKind, primitive::PublicKey, Base64Bytes, NearToken,
 };
 
+fn is_false(value: &bool) -> bool {
+    !value
+}
 /// List deployments in a registry.
 #[derive(MethodSpec, Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[method(read = "registry.listDeployments", output = ListDeploymentsResult)]
@@ -113,8 +116,7 @@ pub struct DeployTarget {
     pub registry_id: AccountId,
     pub name: String,
     pub version_key: String,
-    /// Skip embedded-ABI validation for a deployment whose constructor cannot be checked.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "is_false")]
     pub skip_abi_check: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub full_access_keys: Option<Vec<PublicKey>>,

--- a/gateway/methods-spec/src/registry.rs
+++ b/gateway/methods-spec/src/registry.rs
@@ -6,9 +6,6 @@ use templar_gateway_types::{
     common::Pagination, contract::ContractKind, primitive::PublicKey, Base64Bytes, NearToken,
 };
 
-fn is_false(value: &bool) -> bool {
-    !value
-}
 /// List deployments in a registry.
 #[derive(MethodSpec, Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[method(read = "registry.listDeployments", output = ListDeploymentsResult)]
@@ -116,7 +113,8 @@ pub struct DeployTarget {
     pub registry_id: AccountId,
     pub name: String,
     pub version_key: String,
-    #[serde(default, skip_serializing_if = "is_false")]
+    /// Skip embedded-ABI validation for a deployment whose constructor cannot be checked.
+    #[serde(default)]
     pub skip_abi_check: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub full_access_keys: Option<Vec<PublicKey>>,

--- a/gateway/methods-spec/src/registry.rs
+++ b/gateway/methods-spec/src/registry.rs
@@ -114,7 +114,7 @@ pub struct DeployTarget {
     pub name: String,
     pub version_key: String,
     /// Skip embedded-ABI validation for a deployment whose constructor cannot be checked.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub skip_abi_check: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub full_access_keys: Option<Vec<PublicKey>>,

--- a/gateway/methods-spec/tests/eng_393_method_spec.rs
+++ b/gateway/methods-spec/tests/eng_393_method_spec.rs
@@ -22,6 +22,7 @@ fn target() -> DeployTarget {
         registry_id: near_account_id::AccountIdRef::new_or_panic("registry.near").to_owned(),
         name: "market".to_owned(),
         version_key: "v1.0.0".to_owned(),
+        skip_abi_check: false,
         full_access_keys: None,
         deposit: NearToken::from_near(1),
     }

--- a/gateway/methods-spec/tests/eng_393_method_spec.rs
+++ b/gateway/methods-spec/tests/eng_393_method_spec.rs
@@ -156,6 +156,17 @@ fn deploy_flattens_its_target_into_the_same_flat_json() {
     );
 }
 
+#[test]
+fn deploy_serializes_explicit_abi_check_opt_out() {
+    let mut target = target();
+    target.skip_abi_check = true;
+
+    let request = Deploy::new(target, Base64Bytes(vec![1, 2, 3]));
+    let value = serde_json::to_value(&request).unwrap();
+
+    assert_eq!(value["skip_abi_check"], json!(true));
+}
+
 /// A method's own init fields sit beside the target's on the wire, so the flat body
 /// one method accepts is the flat body every other one accepts.
 #[test]

--- a/gateway/testing/src/ops.rs
+++ b/gateway/testing/src/ops.rs
@@ -1246,10 +1246,9 @@ impl SandboxHarness {
         .await
     }
 
-    /// Deploy a contract from a registry version. The deployed contract lives at
-    /// the sub-account `{name}.{registry_id}`.
+    /// Deploy a contract from a registry version with ABI validation disabled.
     #[allow(clippy::too_many_arguments)]
-    pub async fn registry_deploy(
+    pub async fn registry_deploy_without_abi_check(
         &self,
         caller: &ManagedAccountId,
         registry_id: &AccountId,
@@ -1268,6 +1267,7 @@ impl SandboxHarness {
                     version_key: version_key.to_owned(),
                     full_access_keys,
                     deposit,
+                    skip_abi_check: true,
                 },
                 init_args: Base64Bytes(init_args),
             },

--- a/gateway/types/src/version/proxy_oracle_version.rs
+++ b/gateway/types/src/version/proxy_oracle_version.rs
@@ -10,34 +10,11 @@ impl ProxyOracleVersion {
     pub fn proxy_is_kernelized(self) -> bool {
         self >= (0, 2, 0)
     }
-
-    /// Whether `new` accepts an `owner_id` (`>= 0.3.0`).
-    ///
-    /// Check before sending one. An older `new` takes no arguments, and near-sdk
-    /// only deserializes input for a method that declares some — so it does not
-    /// reject an `owner_id`, it ignores it and seats the predecessor instead.
-    pub fn new_accepts_owner_id(self) -> bool {
-        self >= (0, 3, 0)
-    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::ProxyOracleVersion;
-
-    #[rstest::rstest]
-    #[case((0, 1, 0), false)]
-    #[case((0, 2, 0), false)]
-    #[case((0, 2, 9), false)]
-    #[case((0, 3, 0), true)]
-    #[case((0, 4, 0), true)]
-    #[case((1, 0, 0), true)]
-    fn new_accepts_owner_id_from_0_3_0(#[case] version: (u64, u64, u64), #[case] expected: bool) {
-        assert_eq!(
-            ProxyOracleVersion::from(version).new_accepts_owner_id(),
-            expected,
-        );
-    }
 
     #[test]
     fn from_version_key_reads_the_version_segment() {

--- a/service/gateway/Cargo.toml
+++ b/service/gateway/Cargo.toml
@@ -57,6 +57,7 @@ templar-proxy-oracle-near-governance-common.workspace = true
 templar-universal-account.workspace = true
 test-utils.workspace = true
 wiremock.workspace = true
+zstd = "0.13.3"
 
 [lints]
 workspace = true

--- a/service/gateway/src/rpc/tests/market_tests.rs
+++ b/service/gateway/src/rpc/tests/market_tests.rs
@@ -465,6 +465,7 @@ async fn market_create_endpoint_deploys_from_registry_and_registers_tokens() -> 
                     version_key: "market@1.0.0".to_owned(),
                     full_access_keys: None,
                     deposit: NearToken::from_near(20),
+                    skip_abi_check: true,
                 },
                 configuration: configuration.clone(),
             },

--- a/service/gateway/src/rpc/tests/proxy_oracle_tests.rs
+++ b/service/gateway/src/rpc/tests/proxy_oracle_tests.rs
@@ -494,6 +494,7 @@ async fn governance_create_deploys_an_initialized_contract() -> Result<()> {
                     version_key: "gov@0.2.0".to_owned(),
                     full_access_keys: None,
                     deposit: NearToken::from_near(10),
+                    skip_abi_check: true,
                 },
                 proxy_oracle_id: oracle_id.clone(),
                 admin_id: admin_id.clone(),

--- a/service/gateway/src/rpc/tests/redstone_tests.rs
+++ b/service/gateway/src/rpc/tests/redstone_tests.rs
@@ -131,6 +131,7 @@ async fn redstone_create_deploys_a_configured_adapter() -> Result<()> {
                     version_key: "redstone@0.2.0".to_owned(),
                     full_access_keys: None,
                     deposit: NearToken::from_near(10),
+                    skip_abi_check: true,
                 },
                 config: expected.clone(),
                 admin_id: stack.harness.beneficiary_account_id.clone(),

--- a/service/gateway/src/rpc/tests/registry_tests.rs
+++ b/service/gateway/src/rpc/tests/registry_tests.rs
@@ -231,20 +231,20 @@ async fn add_version_accepts_every_source_and_each_one_deploys() -> Result<()> {
 fn wasm_with_no_arg_constructor_abi() -> Vec<u8> {
     let abi = r#"{"schema_version":"0.4.0","metadata":{},"body":{"functions":[{"name":"new","kind":"call","modifiers":["init"],"params":{"serialization_type":"json","args":[]}}],"root_schema":{"definitions":{}}}}"#;
     let compressed = zstd::stream::encode_all(abi.as_bytes(), 0).expect("compress ABI");
-    let mut section = vec![1, 0, 0x41, 0, 0x0b];
+    let mut data = vec![1, 0, 0x41, 0, 0x0b];
     push_uleb(
-        &mut section,
-        u32::try_from(compressed.len()).expect("compressed ABI fits Wasm section length"),
+        &mut data,
+        u32::try_from(compressed.len()).expect("compressed ABI fits Wasm data segment length"),
     );
-    section.extend(compressed);
+    data.extend(compressed);
 
     let mut wasm = b"\0asm\x01\0\0\0".to_vec();
-    wasm.push(11);
-    push_uleb(
-        &mut wasm,
-        u32::try_from(section.len()).expect("Wasm section fits Wasm section length"),
-    );
-    wasm.extend(section);
+    push_section(&mut wasm, 1, &[1, 0x60, 0, 0]);
+    push_section(&mut wasm, 3, &[1, 0]);
+    push_section(&mut wasm, 5, &[1, 0, 1]);
+    push_section(&mut wasm, 7, &[1, 3, b'n', b'e', b'w', 0, 0]);
+    push_section(&mut wasm, 10, &[1, 2, 0, 0x0b]);
+    push_section(&mut wasm, 11, &data);
     wasm
 }
 
@@ -279,28 +279,38 @@ fn push_uleb(bytes: &mut Vec<u8>, mut value: u32) {
         }
     }
 }
+fn push_section(wasm: &mut Vec<u8>, id: u8, payload: &[u8]) {
+    wasm.push(id);
+    push_uleb(
+        wasm,
+        u32::try_from(payload.len()).expect("Wasm section payload fits u32"),
+    );
+    wasm.extend(payload);
+}
 
 #[tokio::test]
-async fn stored_and_global_versions_reject_invalid_constructor_args() -> Result<()> {
+async fn stored_and_global_versions_validate_constructor_args() -> Result<()> {
     let stack = TestStack::start().await?;
     let registry_id = stack.harness.deploy_registry().await?;
     let wasm = wasm_with_no_arg_constructor_abi();
     let versions = [
         (
-            "uncatalogued@1.0.0",
-            "invalid-init",
+            "stored@1.0.0",
+            "invalid-stored",
+            "valid-stored",
             VersionSource::Stored(wasm.clone().into()),
             NearToken::from_yoctonear(1),
         ),
         (
             "global@1.0.0",
-            "invalid-global-init",
+            "invalid-global",
+            "valid-global",
             VersionSource::PublishGlobal(wasm.clone().into()),
             templar_gateway_testing::publish_deposit_for(wasm.len()),
         ),
     ];
 
-    for (version_key, name, source, deposit) in versions {
+    for (version_key, invalid_name, valid_name, source, deposit) in versions {
         stack
             .harness
             .registry_add_version(
@@ -320,7 +330,7 @@ async fn stored_and_global_versions_reject_invalid_constructor_args() -> Result<
                 body: registry::Deploy {
                     target: registry::DeployTarget {
                         registry_id: registry_id.clone(),
-                        name: name.to_owned(),
+                        name: invalid_name.to_owned(),
                         version_key: version_key.to_owned(),
                         skip_abi_check: false,
                         full_access_keys: None,
@@ -332,16 +342,50 @@ async fn stored_and_global_versions_reject_invalid_constructor_args() -> Result<
             .await
             .expect_err("constructor ABI must reject arguments before deployment");
         assert!(format!("{error}").contains("do not match"));
+
+        let deploy = stack
+            .controller
+            .request::<registry::Deploy>(&WriteRequest {
+                signer_account_id: stack.harness.registry_signer_account_id.clone(),
+                idempotency_key: None,
+                body: registry::Deploy {
+                    target: registry::DeployTarget {
+                        registry_id: registry_id.clone(),
+                        name: valid_name.to_owned(),
+                        version_key: version_key.to_owned(),
+                        skip_abi_check: false,
+                        full_access_keys: None,
+                        deposit: NearToken::from_near(6),
+                    },
+                    init_args: Base64Bytes(Vec::new()),
+                },
+            })
+            .await?;
+        assert_eq!(deploy.operation.status, OperationStatus::Succeeded);
+
+        let account_id: AccountId = format!("{valid_name}.{registry_id}").parse()?;
+        let deployment = stack
+            .controller
+            .request::<registry::GetDeployment>(&registry::GetDeployment {
+                registry_id: registry_id.clone(),
+                account_id,
+            })
+            .await?;
+        assert!(deployment.deployment.is_some());
     }
 
     let deployments = stack
         .controller
         .request::<registry::ListDeployments>(&registry::ListDeployments {
-            registry_id,
+            registry_id: registry_id.clone(),
             args: Pagination::default(),
         })
         .await?;
-    assert!(deployments.account_ids.is_empty());
+    let expected = vec![
+        format!("valid-stored.{registry_id}").parse::<AccountId>()?,
+        format!("valid-global.{registry_id}").parse::<AccountId>()?,
+    ];
+    assert_eq!(deployments.account_ids, expected);
 
     stack.shutdown().await;
     Ok(())

--- a/service/gateway/src/rpc/tests/registry_tests.rs
+++ b/service/gateway/src/rpc/tests/registry_tests.rs
@@ -1,6 +1,7 @@
 use near_account_id::AccountId;
 use near_sdk::json_types::Base58CryptoHash;
 use templar_common::registry::VersionSource;
+use templar_gateway_methods_spec::proxy_oracle;
 use templar_gateway_types::{common::Pagination, ContractKind, OperationStatus};
 
 use super::*;
@@ -48,6 +49,7 @@ async fn registry_endpoints_work_against_sandbox() -> Result<()> {
                     version_key: version_key.clone(),
                     full_access_keys: None,
                     deposit: NearToken::from_near(6),
+                    skip_abi_check: true,
                 },
                 init_args: Base64Bytes(serde_json::to_vec(&serde_json::json!({
                     "name": "Deployed FT",
@@ -205,6 +207,7 @@ async fn add_version_accepts_every_source_and_each_one_deploys() -> Result<()> {
                         version_key: version_key.to_owned(),
                         full_access_keys: None,
                         deposit: NearToken::from_near(6),
+                        skip_abi_check: true,
                     },
                     init_args: Base64Bytes(serde_json::to_vec(&serde_json::json!({
                         "name": "Deployed FT",
@@ -220,6 +223,200 @@ async fn add_version_accepts_every_source_and_each_one_deploys() -> Result<()> {
             "{version_key} should deploy",
         );
     }
+
+    stack.shutdown().await;
+    Ok(())
+}
+
+fn wasm_with_no_arg_constructor_abi() -> Vec<u8> {
+    let abi = r#"{"schema_version":"0.4.0","metadata":{},"body":{"functions":[{"name":"new","kind":"call","modifiers":["init"],"params":{"serialization_type":"json","args":[]}}],"root_schema":{"definitions":{}}}}"#;
+    let compressed = zstd::stream::encode_all(abi.as_bytes(), 0).expect("compress ABI");
+    let mut section = vec![1, 0, 0x41, 0, 0x0b];
+    push_uleb(
+        &mut section,
+        u32::try_from(compressed.len()).expect("compressed ABI fits Wasm section length"),
+    );
+    section.extend(compressed);
+
+    let mut wasm = b"\0asm\x01\0\0\0".to_vec();
+    wasm.push(11);
+    push_uleb(
+        &mut wasm,
+        u32::try_from(section.len()).expect("Wasm section fits Wasm section length"),
+    );
+    wasm.extend(section);
+    wasm
+}
+
+async fn add_stored_abi_version(
+    stack: &TestStack,
+    registry_id: &AccountId,
+    version_key: &str,
+) -> Result<()> {
+    stack
+        .harness
+        .registry_add_version(
+            &stack.harness.registry_signer_account_id,
+            registry_id,
+            version_key,
+            VersionSource::Stored(wasm_with_no_arg_constructor_abi().into()),
+            NearToken::from_yoctonear(1),
+        )
+        .await?;
+    Ok(())
+}
+
+fn push_uleb(bytes: &mut Vec<u8>, mut value: u32) {
+    loop {
+        let mut byte = (value & 0x7f) as u8;
+        value >>= 7;
+        if value != 0 {
+            byte |= 0x80;
+        }
+        bytes.push(byte);
+        if value == 0 {
+            return;
+        }
+    }
+}
+
+#[tokio::test]
+async fn stored_and_global_versions_reject_invalid_constructor_args() -> Result<()> {
+    let stack = TestStack::start().await?;
+    let registry_id = stack.harness.deploy_registry().await?;
+    let wasm = wasm_with_no_arg_constructor_abi();
+    let versions = [
+        (
+            "uncatalogued@1.0.0",
+            "invalid-init",
+            VersionSource::Stored(wasm.clone().into()),
+            NearToken::from_yoctonear(1),
+        ),
+        (
+            "global@1.0.0",
+            "invalid-global-init",
+            VersionSource::PublishGlobal(wasm.clone().into()),
+            templar_gateway_testing::publish_deposit_for(wasm.len()),
+        ),
+    ];
+
+    for (version_key, name, source, deposit) in versions {
+        stack
+            .harness
+            .registry_add_version(
+                &stack.harness.registry_signer_account_id,
+                &registry_id,
+                version_key,
+                source,
+                deposit,
+            )
+            .await?;
+
+        let error = stack
+            .controller
+            .request::<registry::Deploy>(&WriteRequest {
+                signer_account_id: stack.harness.registry_signer_account_id.clone(),
+                idempotency_key: None,
+                body: registry::Deploy {
+                    target: registry::DeployTarget {
+                        registry_id: registry_id.clone(),
+                        name: name.to_owned(),
+                        version_key: version_key.to_owned(),
+                        skip_abi_check: false,
+                        full_access_keys: None,
+                        deposit: NearToken::from_near(6),
+                    },
+                    init_args: Base64Bytes(br#"{"unexpected":true}"#.to_vec()),
+                },
+            })
+            .await
+            .expect_err("constructor ABI must reject arguments before deployment");
+        assert!(format!("{error}").contains("do not match"));
+    }
+
+    let deployments = stack
+        .controller
+        .request::<registry::ListDeployments>(&registry::ListDeployments {
+            registry_id,
+            args: Pagination::default(),
+        })
+        .await?;
+    assert!(deployments.account_ids.is_empty());
+
+    stack.shutdown().await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn removed_version_is_rejected_before_deployment() -> Result<()> {
+    let stack = TestStack::start().await?;
+    let registry_id = stack.harness.deploy_registry().await?;
+    let version_key = "removed@1.0.0".to_owned();
+    add_stored_abi_version(&stack, &registry_id, &version_key).await?;
+    let _ = stack
+        .controller
+        .request::<registry::RemoveVersion>(&WriteRequest {
+            signer_account_id: stack.harness.registry_signer_account_id.clone(),
+            idempotency_key: None,
+            body: registry::RemoveVersion {
+                registry_id: registry_id.clone(),
+                version_key: version_key.clone(),
+            },
+        })
+        .await?;
+
+    let error = stack
+        .controller
+        .request::<registry::Deploy>(&WriteRequest {
+            signer_account_id: stack.harness.registry_signer_account_id.clone(),
+            idempotency_key: None,
+            body: registry::Deploy {
+                target: registry::DeployTarget {
+                    registry_id,
+                    name: "removed-version".to_owned(),
+                    version_key,
+                    skip_abi_check: false,
+                    full_access_keys: None,
+                    deposit: NearToken::from_near(6),
+                },
+                init_args: Base64Bytes(b"{}".to_vec()),
+            },
+        })
+        .await
+        .expect_err("removed version must fail before deployment planning");
+    assert!(format!("{error}").contains("has been removed"));
+
+    stack.shutdown().await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn proxy_oracle_owner_id_is_checked_against_constructor_abi() -> Result<()> {
+    let stack = TestStack::start().await?;
+    let registry_id = stack.harness.deploy_registry().await?;
+    let version_key = "old-proxy@1.0.0".to_owned();
+    add_stored_abi_version(&stack, &registry_id, &version_key).await?;
+
+    let error = stack
+        .controller
+        .request::<proxy_oracle::Create>(&WriteRequest {
+            signer_account_id: stack.harness.registry_signer_account_id.clone(),
+            idempotency_key: None,
+            body: proxy_oracle::Create {
+                target: registry::DeployTarget {
+                    registry_id,
+                    name: "old-proxy".to_owned(),
+                    version_key,
+                    skip_abi_check: false,
+                    full_access_keys: None,
+                    deposit: NearToken::from_near(6),
+                },
+                owner_id: Some("owner.near".parse()?),
+            },
+        })
+        .await
+        .expect_err("owner_id must be rejected by the zero-argument constructor ABI");
+    assert!(format!("{error}").contains("do not match"));
 
     stack.shutdown().await;
     Ok(())

--- a/service/gateway/src/rpc/tests/universal_account_tests.rs
+++ b/service/gateway/src/rpc/tests/universal_account_tests.rs
@@ -117,6 +117,7 @@ async fn universal_account_write_endpoints_work_against_sandbox() -> Result<()> 
                     version_key: "ua@1.0.0".to_owned(),
                     full_access_keys: None,
                     deposit: NearToken::from_near(20),
+                    skip_abi_check: true,
                 },
                 key: signer.id(),
                 chain_id: templar_common::SU128::from(NEAR_TESTNET_CHAIN_ID),

--- a/service/relayer/src/app/args.rs
+++ b/service/relayer/src/app/args.rs
@@ -169,6 +169,13 @@ pub struct UniversalAccount {
     /// Version key of the universal account contract to deploy from the registry.
     #[arg(id = "ua-version-key", long = "ua-version-key", env = "UA_VERSION_KEY")]
     pub version_key: String,
+    /// Bypass embedded-ABI validation when deploying universal accounts from the registry.
+    #[arg(
+        id = "ua-skip-abi-check",
+        long = "ua-skip-abi-check",
+        env = "UA_SKIP_ABI_CHECK"
+    )]
+    pub skip_abi_check: bool,
 }
 
 impl UniversalAccount {

--- a/service/relayer/src/route/universal_account/create.rs
+++ b/service/relayer/src/route/universal_account/create.rs
@@ -336,6 +336,7 @@ pub async fn create(
                     version_key: app.args.ua.version_key.clone(),
                     full_access_keys: None,
                     deposit: NearToken::from_yoctonear(0),
+                    skip_abi_check: false,
                 },
                 Base64Bytes(init_args),
             ),

--- a/service/relayer/src/route/universal_account/create.rs
+++ b/service/relayer/src/route/universal_account/create.rs
@@ -336,7 +336,7 @@ pub async fn create(
                     version_key: app.args.ua.version_key.clone(),
                     full_access_keys: None,
                     deposit: NearToken::from_yoctonear(0),
-                    skip_abi_check: false,
+                    skip_abi_check: app.args.ua.skip_abi_check,
                 },
                 Base64Bytes(init_args),
             ),

--- a/service/relayer/tests/relayer.rs
+++ b/service/relayer/tests/relayer.rs
@@ -400,6 +400,7 @@ async fn init_relayer_app(
             ua_account.as_ref(),
             "--ua-version-key",
             "latest",
+            "--ua-skip-abi-check",
             "--ua-chain-id",
             &chain_id,
             "--ua-pow-difficulty",

--- a/service/relayer/tests/relayer.rs
+++ b/service/relayer/tests/relayer.rs
@@ -257,7 +257,7 @@ impl InitTest {
     ) -> AccountId {
         let deployer = self.harness.registry_signer_account_id.clone();
         self.harness
-            .registry_deploy(
+            .registry_deploy_without_abi_check(
                 &deployer,
                 &self.market_registry,
                 name,

--- a/tools/manager/src/commands/deploy_common.rs
+++ b/tools/manager/src/commands/deploy_common.rs
@@ -19,6 +19,9 @@ pub struct DeployTargetArgs {
     /// contract has version-gated init args can check it before deploying.
     #[arg(long, value_name = "KEY")]
     pub(crate) version_key: String,
+    /// Bypass embedded-ABI validation when the target constructor cannot be checked.
+    #[arg(long)]
+    skip_abi_check: bool,
     #[command(flatten)]
     full_access_keys: FullAccessKeyArgs,
     /// Deposit funding the new account's storage and balance.
@@ -39,6 +42,7 @@ impl DeployTargetArgs {
             registry_id: self.registry_id,
             name: self.name,
             version_key: self.version_key,
+            skip_abi_check: self.skip_abi_check,
             full_access_keys: Some(full_access_keys),
             deposit: self.deposit,
         })

--- a/tools/manager/src/commands/market/plan.rs
+++ b/tools/manager/src/commands/market/plan.rs
@@ -38,6 +38,10 @@ pub struct Plan {
     /// Accept a `decimals` override that disagrees with the token's metadata.
     #[arg(long)]
     pub(crate) accept_decimals_mismatch: bool,
+
+    /// Bypass embedded-ABI validation for every registry deployment in this plan.
+    #[arg(long)]
+    pub(crate) skip_abi_check: bool,
 }
 
 /// Send a plan file.
@@ -57,6 +61,10 @@ pub struct Apply {
     /// but fatal at apply is a plan that can be written and never sent.
     #[arg(long = "skip-check", value_name = "CHECK_ID")]
     pub(crate) skip_check: Vec<String>,
+
+    /// Bypass embedded-ABI validation while rebuilding the plan before submission.
+    #[arg(long)]
+    pub(crate) skip_abi_check: bool,
 
     #[command(flatten)]
     pub(crate) signer: SignerArgs,

--- a/tools/manager/src/commands/proxy_oracle/create.rs
+++ b/tools/manager/src/commands/proxy_oracle/create.rs
@@ -1,8 +1,6 @@
-use anyhow::{bail, Context};
 use clap::Args;
 use near_account_id::AccountId;
 use templar_gateway_methods_spec::proxy_oracle as spec;
-use templar_gateway_types::version::ProxyOracleVersion;
 
 use crate::commands::deploy_common::DeployTargetArgs;
 use crate::commands::signer::SignerArgs;
@@ -11,7 +9,8 @@ use crate::commands::signer::SignerArgs;
 /// access key so the operator retains control of the new account.
 ///
 /// `--owner-id` seats the owner at init, so the oracle can be handed straight to
-/// its governance contract instead of transferred afterwards.
+/// its governance contract. `--skip-abi-check` disables the constructor check
+/// that normally rejects a target that ignores this argument.
 #[derive(Args, Debug)]
 pub struct Create {
     #[command(flatten)]
@@ -23,38 +22,8 @@ pub struct Create {
     pub(crate) signer: SignerArgs,
 }
 
-/// Refuse an `owner_id` the named version would ignore — the deploy would
-/// otherwise succeed and leave the registry as owner.
-///
-/// Only as good as the version key, which is a convention the registry does not
-/// enforce (see [`Version::from_version_key`]). An operator guardrail, hence the
-/// CLI and not the gateway; ENG-463 replaces it with a check against the
-/// contract's own ABI.
-///
-/// [`Version::from_version_key`]: templar_gateway_types::version::Version::from_version_key
-pub(crate) fn check_owner_id_is_honored(
-    version_key: &str,
-    owner_id: &AccountId,
-) -> anyhow::Result<()> {
-    let version = ProxyOracleVersion::from_version_key(version_key)
-        .with_context(|| format!("cannot tell whether {version_key} honors --owner-id"))?;
-
-    if !version.new_accepts_owner_id() {
-        bail!(
-            "proxy oracle {version} cannot seat --owner-id {owner_id}: its `new` takes no \
-             arguments, so the registry would own the oracle. Deploy >= 0.3.0."
-        );
-    }
-
-    Ok(())
-}
-
 impl Create {
     pub fn try_into_spec(self) -> anyhow::Result<spec::Create> {
-        if let Some(owner_id) = &self.owner_id {
-            check_owner_id_is_honored(&self.target.version_key, owner_id)?;
-        }
-
         let signer = self.signer;
         Ok(spec::Create {
             target: self.target.resolve(|| signer.public_key())?,

--- a/tools/manager/src/commands/proxy_oracle/mod.rs
+++ b/tools/manager/src/commands/proxy_oracle/mod.rs
@@ -8,7 +8,6 @@ mod price_feed_exists;
 mod update_prices;
 mod upgrade;
 
-pub(crate) use create::check_owner_id_is_honored;
 pub use create::Create;
 pub use get_proxy::GetProxy;
 pub use get_proxy_circuit_breaker_set::GetProxyCircuitBreakerSet;
@@ -27,6 +26,7 @@ use templar_common::oracle::pyth::PriceIdentifier;
 #[command(rename_all = "kebab-case")]
 pub enum ProxyOracleNs {
     /// Deploy a proxy oracle from a registry, optionally owned by `--owner-id`.
+    /// `--skip-abi-check` can disable the constructor check for an incompatible target.
     Create(Create),
     /// Administer a proxy oracle through its governance contract.
     #[command(subcommand, visible_alias = "gov")]

--- a/tools/manager/src/commands/redstone/create.rs
+++ b/tools/manager/src/commands/redstone/create.rs
@@ -1,11 +1,10 @@
 use std::path::PathBuf;
 
-use anyhow::{bail, Context as _};
+use anyhow::Context as _;
 use clap::{Args, ValueEnum};
 use near_account_id::AccountId;
 use templar_common::oracle::redstone::{config, Config};
 use templar_gateway_methods_spec::redstone as spec;
-use templar_gateway_types::version::RedstoneAdapterVersion;
 
 use crate::commands::deploy_common::DeployTargetArgs;
 use crate::commands::load_json_file;
@@ -46,32 +45,8 @@ pub struct Create {
     pub(crate) signer: SignerArgs,
 }
 
-/// Reject a target adapter version whose `new` does not require `admin_id`.
-///
-/// Only as good as the version key, which is a convention the registry does not
-/// enforce (see [`Version::from_version_key`]). An operator guardrail, hence the
-/// CLI and not the gateway; ENG-463 replaces it with a check against the
-/// contract's own ABI.
-///
-/// [`Version::from_version_key`]: templar_gateway_types::version::Version::from_version_key
-fn check_new_requires_admin_id(version_key: &str) -> anyhow::Result<()> {
-    let version = RedstoneAdapterVersion::from_version_key(version_key)
-        .with_context(|| format!("cannot tell whether {version_key} requires admin_id"))?;
-
-    if !version.new_requires_admin_id() {
-        bail!(
-            "RedStone adapter {version} does not require admin_id, so a missing custom init \
-             argument could seed the registry. Deploy >= 0.2.0."
-        );
-    }
-
-    Ok(())
-}
-
 impl Create {
     pub fn try_into_spec(self) -> anyhow::Result<spec::Create> {
-        check_new_requires_admin_id(&self.target.version_key)?;
-
         let config: Config = match self.preset {
             Some(Preset::Prod) => config::prod(),
             Some(Preset::Test) => config::test(),

--- a/tools/manager/src/dispatch/plan.rs
+++ b/tools/manager/src/dispatch/plan.rs
@@ -76,8 +76,16 @@ pub(super) async fn plan(ctx: CliContext, args: Plan) -> anyhow::Result<()> {
     gate(&mut reporter, spec.market_id()?.as_str())?;
 
     let public_key = PublicKey::from(args.public_key);
-    let steps =
-        PlanFile::steps_from(build(&ctx.client, &spec, &public_key, &args.signer_id).await?)?;
+    let steps = PlanFile::steps_from(
+        build(
+            &ctx.client,
+            &spec,
+            &public_key,
+            &args.signer_id,
+            args.skip_abi_check,
+        )
+        .await?,
+    )?;
 
     // After the steps exist, because it reads them; before the plan is written,
     // because a signer that cannot pay is a reason not to write one.
@@ -122,8 +130,16 @@ pub(super) async fn apply(ctx: CliContext, args: Apply) -> anyhow::Result<()> {
     // What the spec derives right now. Re-derived rather than inspected: a plan
     // is a record of this derivation, so anything an edit could break is caught
     // by one comparison instead of a guard per property.
-    let expected =
-        PlanFile::steps_from(build(&ctx.client, &file.spec, &file.public_key, &credential).await?)?;
+    let expected = PlanFile::steps_from(
+        build(
+            &ctx.client,
+            &file.spec,
+            &file.public_key,
+            &credential,
+            args.skip_abi_check,
+        )
+        .await?,
+    )?;
 
     // Reconciled before anything else that reads the steps: if the journal and
     // the plan disagree, nothing below is meaningful.
@@ -449,6 +465,7 @@ pub(crate) async fn build(
     spec: &MarketSpec,
     public_key: &PublicKey,
     signer_id: &AccountId,
+    skip_abi_check: bool,
 ) -> anyhow::Result<Vec<(String, PlannedTransaction)>> {
     // A plan is a fixed list of transactions; it cannot encode "wait". With a
     // non-zero TTL the two proxy proposals are not executable when they are
@@ -517,8 +534,11 @@ pub(crate) async fn build(
             spec,
             public_key,
             governance,
-            oracle_version,
-            governance_version,
+            ProxyDeploymentOptions {
+                oracle_version,
+                governance_version,
+                skip_abi_check,
+            },
         )
         .await?;
 
@@ -563,6 +583,7 @@ pub(crate) async fn build(
                     registry_id: spec.registry.clone(),
                     name: spec.name.clone(),
                     version_key: spec.market_version.clone(),
+                    skip_abi_check,
                     full_access_keys,
                     deposit: MARKET_DEPOSIT,
                 },
@@ -575,6 +596,12 @@ pub(crate) async fn build(
     Ok(steps)
 }
 
+struct ProxyDeploymentOptions<'a> {
+    oracle_version: &'a str,
+    governance_version: &'a str,
+    skip_abi_check: bool,
+}
+
 /// The governance contract, then the oracle it owns: the oracle names its
 /// governance as `owner_id` at init, so governance must exist first.
 async fn oracle_stack(
@@ -583,20 +610,11 @@ async fn oracle_stack(
     spec: &MarketSpec,
     public_key: &PublicKey,
     governance: &GovernanceSpec,
-    oracle_version: &str,
-    governance_version: &str,
+    options: ProxyDeploymentOptions<'_>,
 ) -> anyhow::Result<Vec<(String, PlannedTransaction)>> {
     let full_access_keys = Some(vec![public_key.clone()]);
     let governance_id = spec.governance_id()?;
     let oracle_id = spec.oracle_id()?;
-
-    // Constructing the gateway request directly bypasses the guard
-    // `proxy-oracle create` applies, so it is applied here too: a pre-0.3.0
-    // `new` ignores `owner_id`, leaving the registry as owner. Governance then
-    // cannot configure either proxy — and because `admin_set_proxy` is
-    // dispatched detached, the proposals still *report* success and the deploy
-    // reaches market creation with an unconfigured oracle.
-    crate::commands::proxy_oracle::check_owner_id_is_honored(oracle_version, &governance_id)?;
 
     let mut steps = step(
         client,
@@ -606,7 +624,8 @@ async fn oracle_stack(
             target: registry::DeployTarget {
                 registry_id: spec.registry.clone(),
                 name: crate::spec::governance_name(&spec.name),
-                version_key: governance_version.to_owned(),
+                version_key: options.governance_version.to_owned(),
+                skip_abi_check: options.skip_abi_check,
                 full_access_keys: full_access_keys.clone(),
                 deposit: GOVERNANCE_DEPOSIT,
             },
@@ -629,7 +648,8 @@ async fn oracle_stack(
                 target: registry::DeployTarget {
                     registry_id: spec.registry.clone(),
                     name: crate::spec::oracle_name(&spec.name),
-                    version_key: oracle_version.to_owned(),
+                    version_key: options.oracle_version.to_owned(),
+                    skip_abi_check: options.skip_abi_check,
                     full_access_keys,
                     deposit: ORACLE_DEPOSIT,
                 },

--- a/tools/manager/src/tests/plan_file.rs
+++ b/tools/manager/src/tests/plan_file.rs
@@ -286,134 +286,13 @@ async fn a_signer_that_is_not_the_governance_admin_is_refused() {
         "the fixture must not already agree, or this proves nothing"
     );
 
-    let error = crate::dispatch::plan::build(&client, &spec, &public_key, &signer_id())
+    let error = crate::dispatch::plan::build(&client, &spec, &public_key, &signer_id(), false)
         .await
         .expect_err("a non-admin signer cannot execute the proxy proposals");
 
     assert!(
         format!("{error:#}").contains("would not hold the Admin role"),
         "{error:#}"
-    );
-}
-
-/// A proxy-oracle version whose `new` ignores `owner_id` leaves the *registry*
-/// as owner, so governance can never configure either proxy. Because
-/// `admin_set_proxy` is dispatched detached, the proposals would still report
-/// success and the deploy would reach market creation with a dead oracle — so
-/// this is refused at plan time. Offline: the guard precedes the first read.
-#[tokio::test]
-async fn an_oracle_version_that_ignores_owner_id_is_refused() {
-    let client = Client::builder(NetworkConfigBuilder::new(Network::Mainnet).build())
-        .build()
-        .expect("build client");
-    let public_key = public_key();
-    let mut spec = alpha_market();
-    let crate::spec::OracleMode::Proxy {
-        governance,
-        oracle_version,
-        ..
-    } = &mut spec.oracle
-    else {
-        panic!("the fixture must be a proxy market");
-    };
-    let admin = governance.admin.clone();
-    // Well-formed key, pre-0.3.0 version: the guard must reject it for what the
-    // version *means*, not because the key failed to parse. Rebuilt rather than
-    // substituted, so a profile version bump cannot silently make this a no-op.
-    let (name, hash) = oracle_version
-        .split_once('@')
-        .and_then(|(name, rest)| rest.split_once('#').map(|(_, hash)| (name, hash)))
-        .expect("fixture version key is `<name>@<version>#<hash>`");
-    *oracle_version = format!("{name}@0.2.0#{hash}");
-
-    let error = crate::dispatch::plan::build(&client, &spec, &public_key, &admin)
-        .await
-        .expect_err("a pre-0.3.0 oracle cannot seat an owner");
-
-    assert!(
-        format!("{error:#}").contains("registry would own the oracle"),
-        "{error:#}"
-    );
-}
-
-/// The full proxy deployment, in order.
-///
-/// The order is a safety property: `registry deploy` fails when the account
-/// already exists, so governance must be created before the oracle names it as
-/// owner, and both before the market points at the oracle.
-///
-/// Needs the network: planning a registry deploy reads the registry's contract
-/// source metadata to pick the init-args encoding.
-#[tokio::test]
-async fn requires_network_plans_the_deploy_script_in_order() {
-    let client = Client::builder(NetworkConfigBuilder::new(Network::Mainnet).build())
-        .build()
-        .expect("build client");
-    let public_key = public_key();
-
-    // Signed by the spec's `governance.admin`: any other account would not hold
-    // the Admin role, and `build` refuses that rather than plan a deployment
-    // whose proposals revert after the deposits are already spent.
-    let spec = alpha_market();
-    let admin = spec.proxy().expect("proxy fixture").0.admin.clone();
-    let labeled = crate::dispatch::plan::build(&client, &spec, &public_key, &admin)
-        .await
-        .expect("the alpha fixture should plan");
-
-    let sequence: Vec<_> = labeled
-        .iter()
-        .map(|(label, transaction)| {
-            let method = match transaction.actions.as_slice() {
-                [Action::FunctionCall(call)] => call.method_name.as_str(),
-                other => panic!("expected one function call, got {other:?}"),
-            };
-            (transaction.receiver_id.as_str(), method, label.as_str())
-        })
-        .collect();
-
-    // The three registry deploys share one method (`deploy_market`) and one
-    // receiver, so the label is what identifies each — asserted for that reason.
-    assert_eq!(
-        sequence,
-        vec![
-            (
-                "templar-alpha.near",
-                "deploy_market",
-                "deploy governance proxy-gov-iethfxrp-ixlmusdc.templar-alpha.near"
-            ),
-            (
-                "templar-alpha.near",
-                "deploy_market",
-                "deploy proxy oracle proxy-oracle-iethfxrp-ixlmusdc.templar-alpha.near, \
-                 owned by governance"
-            ),
-            (
-                "proxy-gov-iethfxrp-ixlmusdc.templar-alpha.near",
-                "create_proposal",
-                "propose collateral proxy (proposal 0)"
-            ),
-            (
-                "proxy-gov-iethfxrp-ixlmusdc.templar-alpha.near",
-                "execute_proposal",
-                "execute collateral proxy proposal 0"
-            ),
-            (
-                "proxy-gov-iethfxrp-ixlmusdc.templar-alpha.near",
-                "create_proposal",
-                "propose borrow proxy (proposal 1)"
-            ),
-            (
-                "proxy-gov-iethfxrp-ixlmusdc.templar-alpha.near",
-                "execute_proposal",
-                "execute borrow proxy proposal 1"
-            ),
-            (
-                "templar-alpha.near",
-                "deploy_market",
-                "deploy market iethfxrp-ixlmusdc.templar-alpha.near"
-            ),
-        ],
-        "the plan must deploy governance, then the oracle it owns, then the market"
     );
 }
 

--- a/tools/manager/src/tests/proxy_oracle.rs
+++ b/tools/manager/src/tests/proxy_oracle.rs
@@ -161,8 +161,6 @@ fn upgrade_reads_local_wasm_and_carries_the_migration() {
 }
 
 const V0_3_0: &str = "templar-proxy-oracle-near-contract@0.3.0#ab";
-const V0_2_0: &str = "templar-proxy-oracle-near-contract@0.2.0#ab";
-const UNREADABLE: &str = "templar-proxy-oracle-near-contract-0.3.0";
 
 /// `--owner-id` reaches the gateway spec as a typed account id, not a JSON string
 /// interpolated by the caller.
@@ -176,36 +174,6 @@ fn create_carries_owner_id_into_the_gateway_spec() {
     let json = serde_json::to_value(&spec).unwrap();
     serde_json::from_value::<templar_gateway_methods_spec::proxy_oracle::Create>(json)
         .expect("create params should match the gateway spec");
-}
-
-/// The guard fires only when an owner is named: an old `new` silently drops one,
-/// and an unreadable key cannot be shown to accept one. With no owner there is
-/// nothing to drop, so neither may be refused.
-#[rstest::rstest]
-#[case::honored(V0_3_0, Some("gov.testnet"), None)]
-#[case::ignored(V0_2_0, Some("gov.testnet"), Some("takes no arguments"))]
-#[case::unreadable(UNREADABLE, Some("gov.testnet"), Some("cannot tell whether"))]
-#[case::no_owner_new(V0_3_0, None, None)]
-#[case::no_owner_old(V0_2_0, None, None)]
-#[case::no_owner_unreadable(UNREADABLE, None, None)]
-fn create_guards_owner_id_against_the_named_version(
-    #[case] version_key: &str,
-    #[case] owner_id: Option<&str>,
-    #[case] expected_error: Option<&str>,
-) {
-    let result = oracle_create(version_key, owner_id);
-
-    match expected_error {
-        None => {
-            let spec = result.expect("into spec");
-            assert_eq!(spec.owner_id, owner_id.map(|id| id.parse().unwrap()));
-        }
-        Some(expected) => {
-            let error = result.expect_err("guard should refuse");
-            let message = format!("{error:#}");
-            assert!(message.contains(expected), "{message}");
-        }
-    }
 }
 
 #[test]

--- a/tools/manager/src/tests/redstone.rs
+++ b/tools/manager/src/tests/redstone.rs
@@ -5,9 +5,7 @@ use super::CREDS;
 use crate::cli::{Cli, Command};
 use crate::commands::RedstoneNs;
 
-/// An adapter version whose `new` requires `admin_id`, and one whose `new` does not.
 const VERSION_WITH_ADMIN: &str = "templar-redstone-adapter-contract@0.2.0#abc";
-const VERSION_WITHOUT_ADMIN: &str = "templar-redstone-adapter-contract@0.1.0#abc";
 
 #[test]
 fn write_prices_decodes_base64_payload() {
@@ -213,14 +211,15 @@ fn create_requires_an_admin_id() {
     );
 }
 
-/// The version guard still fires on the typed path: a pre-0.2.0 `new` ignores an
-/// `admin_id` it does not declare, leaving the registry as admin.
 #[test]
-fn create_rejects_version_without_required_admin_id() {
-    let error = create(VERSION_WITHOUT_ADMIN, &["--preset", "prod"])
-        .expect_err("an optional-admin adapter must be refused");
+fn create_carries_the_abi_check_opt_out() {
+    let spec = create(
+        "templar-redstone-adapter-contract@unreadable",
+        &["--preset", "prod", "--skip-abi-check"],
+    )
+    .expect("the explicit opt-out must not parse the version key");
 
-    assert!(error.to_string().contains("Deploy >= 0.2.0"));
+    assert!(spec.target.skip_abi_check);
 }
 
 #[rstest::rstest]


### PR DESCRIPTION
## Summary
- resolve registry WASM by trusted hash across catalogued, global, and stored versions
- validate JSON init args against the embedded constructor ABI before deployment planning
- replace version-key constructor heuristics with shared ABI validation and explicit opt-out

## Verification
- cargo check --workspace
- cargo test -p templar-gateway-methods-dispatch --lib -- --nocapture
- cargo test -p templar-manager -- --nocapture
- cargo test -p templar-gateway-core --lib -- --nocapture
- cargo test -p templar-gateway-catalog methods_md_is_up_to_date
- just test-sandbox -p templar-gateway-service --test-threads=1 --stale
- cargo fmt --all --check
- affected-package cargo clippy --all-targets -- -D warnings

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/607)
<!-- Reviewable:end -->
