### PR TITLE
ci: default workflows to GitHub-hosted runners

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   build-and-deploy:
     name: Build documentation and deploy
-    runs-on: warp-ubuntu-latest-x64-4x
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       pages: write

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -26,7 +26,7 @@ permissions:
 jobs:
   list-targets:
     name: List targets
-    runs-on: warp-ubuntu-latest-x64-4x
+    runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.list.outputs.matrix }}
     steps:
@@ -70,7 +70,7 @@ jobs:
   fuzz:
     name: Fuzz ${{ matrix.target }}
     needs: list-targets
-    runs-on: warp-ubuntu-latest-x64-4x
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:
       fail-fast: false

--- a/.github/workflows/gas-report.yml
+++ b/.github/workflows/gas-report.yml
@@ -10,7 +10,7 @@ jobs:
   # Add a job to check if relevant files changed
   check-changes:
     name: Check for relevant changes
-    runs-on: warp-ubuntu-latest-x64-4x
+    runs-on: ubuntu-latest
     outputs:
       should-run: ${{ steps.changes.outputs.contracts }}
     steps:
@@ -32,7 +32,7 @@ jobs:
 
   gas-report:
     name: Gas report
-    runs-on: warp-ubuntu-latest-x64-4x
+    runs-on: ubuntu-latest
     needs: check-changes
     # Only run if there are relevant changes
     if: needs.check-changes.outputs.should-run == 'true'

--- a/.github/workflows/kani.yml
+++ b/.github/workflows/kani.yml
@@ -33,7 +33,7 @@ env:
 jobs:
   universal-account:
     name: Universal Account
-    runs-on: warp-ubuntu-latest-x64-4x
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
       - name: Checkout repository
@@ -50,7 +50,7 @@ jobs:
 
   vault-kernel:
     name: Vault Kernel
-    runs-on: warp-ubuntu-latest-x64-4x
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
       - name: Checkout repository
@@ -67,7 +67,7 @@ jobs:
 
   vault-kernel-sync-external:
     name: Vault Kernel / Sync External
-    runs-on: warp-ubuntu-latest-x64-4x
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
       - name: Checkout repository
@@ -93,7 +93,7 @@ jobs:
 
   vault-kernel-withdraw-escrow:
     name: Vault Kernel / Withdraw Escrow
-    runs-on: warp-ubuntu-latest-x64-4x
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
       - name: Checkout repository
@@ -112,7 +112,7 @@ jobs:
 
   vault-kernel-allocation-lifecycle:
     name: Vault Kernel / Allocation Lifecycle
-    runs-on: warp-ubuntu-latest-x64-4x
+    runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
       - name: Checkout repository
@@ -134,7 +134,7 @@ jobs:
 
   vault-kernel-refresh-lifecycle:
     name: Vault Kernel / Refresh Lifecycle
-    runs-on: warp-ubuntu-latest-x64-4x
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
       - name: Checkout repository
@@ -154,7 +154,7 @@ jobs:
 
   vault-kernel-recovery:
     name: Vault Kernel / Recovery
-    runs-on: warp-ubuntu-latest-x64-4x
+    runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
       - name: Checkout repository
@@ -177,7 +177,7 @@ jobs:
 
   vault-kernel-refresh-fees:
     name: Vault Kernel / Refresh Fees
-    runs-on: warp-ubuntu-latest-x64-4x
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
       - name: Checkout repository

--- a/.github/workflows/publish-soroban-vault-cli.yml
+++ b/.github/workflows/publish-soroban-vault-cli.yml
@@ -33,7 +33,7 @@ permissions:
 jobs:
   publish:
     name: Build and push GHCR image
-    runs-on: warp-ubuntu-latest-x64-4x
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,7 @@ env:
 jobs:
   changes:
     name: Change Detection
-    runs-on: warp-ubuntu-latest-x64-4x
+    runs-on: ubuntu-latest
     outputs:
       near_integration: ${{ steps.filter.outputs.near_integration }}
       soroban: ${{ steps.filter.outputs.soroban }}
@@ -210,7 +210,7 @@ jobs:
 
   code-formatting:
     name: Code Formatting
-    runs-on: warp-ubuntu-latest-x64-4x
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -220,7 +220,7 @@ jobs:
 
   code-linter:
     name: Code Linter
-    runs-on: warp-ubuntu-latest-x64-4x
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -235,7 +235,7 @@ jobs:
 
   documentation:
     name: Documentation
-    runs-on: warp-ubuntu-latest-x64-4x
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -249,7 +249,7 @@ jobs:
 
   binary-build:
     name: Binary Build
-    runs-on: warp-ubuntu-latest-x64-4x
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -270,7 +270,7 @@ jobs:
 
   soroban:
     name: Soroban
-    runs-on: warp-ubuntu-latest-x64-4x
+    runs-on: ubuntu-latest
     needs: changes
     timeout-minutes: 30
     if: ${{ needs.changes.outputs.run_soroban == 'true' }}
@@ -327,7 +327,7 @@ jobs:
 
   feature-matrix:
     name: Feature Matrix (${{ matrix.name }})
-    runs-on: warp-ubuntu-latest-x64-4x
+    runs-on: ubuntu-latest
     needs: changes
     if: ${{ needs.changes.outputs.run_feature_matrix == 'true' }}
     strategy:
@@ -431,7 +431,7 @@ jobs:
   fast-tests:
     name: Fast Tests
     timeout-minutes: 25
-    runs-on: warp-ubuntu-latest-x64-4x
+    runs-on: ubuntu-latest
     services:
       # The relayer / gateway-store `#[sqlx::test]` tests provision a fresh
       # database per test, so they need a reachable postgres at runtime.
@@ -482,7 +482,7 @@ jobs:
     # prebuild's ABI pass is skipped and rust-cache is dev-seeded. The headroom
     # over 40 avoids a cold-run variance kill wasting a whole run.
     timeout-minutes: 45
-    runs-on: warp-ubuntu-latest-x64-4x
+    runs-on: ubuntu-latest
     services:
       # The relayer's node-backed `#[sqlx::test]` fixtures need Postgres.
       postgres: *postgres_service
@@ -534,7 +534,7 @@ jobs:
   artifact-drift-check:
     name: Artifact Drift Check
     timeout-minutes: 15
-    runs-on: warp-ubuntu-latest-x64-4x
+    runs-on: ubuntu-latest
     needs: changes
     if: ${{ needs.changes.outputs.run_near_integration == 'true' || needs.changes.outputs.artifact_manifests == 'true' }}
     steps:
@@ -588,7 +588,7 @@ jobs:
 
   coverage:
     name: Coverage
-    runs-on: warp-ubuntu-latest-x64-4x
+    runs-on: ubuntu-latest
     needs: changes
     timeout-minutes: 40
     permissions:
@@ -653,7 +653,7 @@ jobs:
 
   full-required-gate:
     name: Full Required Gate
-    runs-on: warp-ubuntu-latest-x64-4x
+    runs-on: ubuntu-latest
     if: ${{ always() }}
     needs:
       - changes


### PR DESCRIPTION
## Summary
- Move every paid WarpBuild Cloud workflow job in `contracts` to `ubuntu-latest`.
- Preserve workflow triggers, permissions, timeouts, dependencies, concurrency controls, and steps.

## Rationale
July's GitHub usage export shows this public repository had $0 net GitHub Actions cost. WarpBuild billed $162.11 for `contracts` through August 25, so GitHub-hosted runners are the cost-first default.

## Verification
- Parsed all six modified workflow YAML files; all 26 jobs resolve to `ubuntu-latest`.
- `git diff --check`
- Confirmed no `warp-ubuntu-latest` labels remain under `.github/workflows`.
- `actionlint` is not installed locally. The first PR run validates the hosted runner switch, including gas reporting, GHCR publishing, and Pages deployment paths.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/608)
<!-- Reviewable:end -->
