### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4452,7 +4452,7 @@ dependencies = [
 
 [[package]]
 name = "harvest-static-yield"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "anyhow",
  "clap",
@@ -12959,7 +12959,7 @@ dependencies = [
 
 [[package]]
 name = "templar-accumulator"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "anyhow",
  "clap",
@@ -13053,7 +13053,7 @@ dependencies = [
 
 [[package]]
 name = "templar-funding-bridge"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -13123,7 +13123,7 @@ dependencies = [
 
 [[package]]
 name = "templar-gateway-artifacts-dispatch"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "async-trait",
  "near-account-id",
@@ -13141,7 +13141,7 @@ dependencies = [
 
 [[package]]
 name = "templar-gateway-artifacts-spec"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "near-account-id",
  "schemars 0.8.22",
@@ -13165,7 +13165,7 @@ dependencies = [
 
 [[package]]
 name = "templar-gateway-client"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "clap",
  "near-api",
@@ -13183,7 +13183,7 @@ dependencies = [
 
 [[package]]
 name = "templar-gateway-core"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "actix",
  "anyhow",
@@ -13235,7 +13235,7 @@ dependencies = [
 
 [[package]]
 name = "templar-gateway-methods-dispatch"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "borsh 1.6.1",
@@ -13266,7 +13266,7 @@ dependencies = [
 
 [[package]]
 name = "templar-gateway-methods-spec"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "near-account-id",
  "schemars 0.8.22",
@@ -13284,7 +13284,7 @@ dependencies = [
 
 [[package]]
 name = "templar-gateway-oracle-updates-dispatch"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -13322,7 +13322,7 @@ dependencies = [
 
 [[package]]
 name = "templar-gateway-oracle-updates-spec"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "hex",
  "near-account-id",
@@ -13337,7 +13337,7 @@ dependencies = [
 
 [[package]]
 name = "templar-gateway-runtime"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "actix",
  "async-trait",
@@ -13351,7 +13351,7 @@ dependencies = [
 
 [[package]]
 name = "templar-gateway-service"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "actix",
  "anyhow",
@@ -13402,7 +13402,7 @@ dependencies = [
 
 [[package]]
 name = "templar-gateway-store"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "async-trait",
  "borsh 1.6.1",
@@ -13457,7 +13457,7 @@ dependencies = [
 
 [[package]]
 name = "templar-gateway-types"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "base64 0.22.1",
  "borsh 1.6.1",
@@ -13480,7 +13480,7 @@ dependencies = [
 
 [[package]]
 name = "templar-liquidator"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -13514,7 +13514,7 @@ dependencies = [
 
 [[package]]
 name = "templar-lst-oracle-contract"
-version = "1.2.5"
+version = "1.2.6"
 dependencies = [
  "anyhow",
  "getrandom 0.2.17",
@@ -13534,7 +13534,7 @@ dependencies = [
 
 [[package]]
 name = "templar-manager"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -13586,7 +13586,7 @@ dependencies = [
 
 [[package]]
 name = "templar-market-contract"
-version = "1.5.2"
+version = "1.5.3"
 dependencies = [
  "anyhow",
  "getrandom 0.2.17",
@@ -13634,7 +13634,7 @@ dependencies = [
 
 [[package]]
 name = "templar-patch-state-contract"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -13717,7 +13717,7 @@ dependencies = [
 
 [[package]]
 name = "templar-proxy-oracle-near-contract"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -13755,7 +13755,7 @@ dependencies = [
 
 [[package]]
 name = "templar-proxy-oracle-near-governance-contract"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -13908,7 +13908,7 @@ dependencies = [
 
 [[package]]
 name = "templar-registry-contract"
-version = "2.0.1"
+version = "3.0.0"
 dependencies = [
  "anyhow",
  "getrandom 0.2.17",
@@ -13927,7 +13927,7 @@ dependencies = [
 
 [[package]]
 name = "templar-relayer"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -14090,7 +14090,7 @@ dependencies = [
 
 [[package]]
 name = "templar-tools-common"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "cargo_metadata 0.23.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,18 +146,18 @@ templar-common = { path = "./common", version = "2.0.0" }
 templar-contract-artifacts = { path = "./contract/artifacts" }
 templar-gateway-artifacts-dispatch = { path = "./gateway/artifacts-dispatch" }
 templar-gateway-artifacts-spec = { path = "./gateway/artifacts-spec" }
-templar-gateway-client = { path = "./gateway/client", version = "0.2.3" }
-templar-gateway-core = { path = "./gateway/core", version = "0.4.1" }
+templar-gateway-client = { path = "./gateway/client", version = "0.2.4" }
+templar-gateway-core = { path = "./gateway/core", version = "0.5.0" }
 templar-gateway-macros = { path = "./gateway/macros", version = "0.1.1" }
-templar-gateway-methods-dispatch = { path = "./gateway/methods-dispatch", version = "0.4.1" }
-templar-gateway-methods-spec = { path = "./gateway/methods-spec", version = "0.4.1" }
+templar-gateway-methods-dispatch = { path = "./gateway/methods-dispatch", version = "0.5.0" }
+templar-gateway-methods-spec = { path = "./gateway/methods-spec", version = "0.5.0" }
 templar-gateway-oracle-updates-dispatch = { path = "./gateway/oracle-updates-dispatch" }
 templar-gateway-oracle-updates-spec = { path = "./gateway/oracle-updates-spec" }
 templar-gateway-runtime = { path = "./gateway/runtime" }
 templar-sandbox = { path = "./gateway/sandbox", version = "0.1.0" }
-templar-gateway-store = { path = "./gateway/store", version = "0.2.2" }
+templar-gateway-store = { path = "./gateway/store", version = "0.2.3" }
 templar-gateway-testing = { path = "./gateway/testing" }
-templar-gateway-types = { path = "./gateway/types", version = "0.3.1" }
+templar-gateway-types = { path = "./gateway/types", version = "0.4.0" }
 templar-patch-state-types = { path = "./contract/patch-state/types", version = "0.1.0" }
 templar-primitives = { path = "./primitives", version = "0.1.2" }
 templar-proxy-oracle-governance-kernel = { path = "./contract/proxy-oracle/governance-kernel", version = "0.2.1" }

--- a/contract/market/Cargo.toml
+++ b/contract/market/Cargo.toml
@@ -4,7 +4,7 @@ rust-version.workspace = true
 license.workspace = true
 name = "templar-market-contract"
 repository.workspace = true
-version = "1.5.2"
+version = "1.5.3"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/contract/patch-state/Cargo.toml
+++ b/contract/patch-state/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "templar-patch-state-contract"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/contract/proxy-oracle/near/contract/Cargo.toml
+++ b/contract/proxy-oracle/near/contract/Cargo.toml
@@ -4,7 +4,7 @@ rust-version.workspace = true
 license.workspace = true
 name = "templar-proxy-oracle-near-contract"
 repository.workspace = true
-version = "0.4.4"
+version = "0.4.5"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/contract/proxy-oracle/near/governance-contract/Cargo.toml
+++ b/contract/proxy-oracle/near/governance-contract/Cargo.toml
@@ -4,7 +4,7 @@ rust-version.workspace = true
 license.workspace = true
 name = "templar-proxy-oracle-near-governance-contract"
 repository.workspace = true
-version = "0.3.3"
+version = "0.3.4"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/contract/proxy-oracle/near/lst-contract/Cargo.toml
+++ b/contract/proxy-oracle/near/lst-contract/Cargo.toml
@@ -4,7 +4,7 @@ rust-version.workspace = true
 license.workspace = true
 name = "templar-lst-oracle-contract"
 repository.workspace = true
-version = "1.2.5"
+version = "1.2.6"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/contract/registry/CHANGELOG.md
+++ b/contract/registry/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.0](https://github.com/Templar-Protocol/contracts/compare/templar-registry-contract-v2.0.1...templar-registry-contract-v3.0.0) - 2026-09-01
+
+### Added
+
+- *(gateway)* [**breaking**] validate registry init args against ABI (ENG-463) ([#607](https://github.com/Templar-Protocol/contracts/pull/607))
+
 ## [2.0.0](https://github.com/Templar-Protocol/contracts/compare/templar-registry-contract-v1.2.4...templar-registry-contract-v2.0.0) - 2026-08-24
 
 ### Added

--- a/contract/registry/Cargo.toml
+++ b/contract/registry/Cargo.toml
@@ -4,7 +4,7 @@ rust-version.workspace = true
 license.workspace = true
 name = "templar-registry-contract"
 repository.workspace = true
-version = "2.0.1"
+version = "3.0.0"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/gateway/artifacts-dispatch/Cargo.toml
+++ b/gateway/artifacts-dispatch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "templar-gateway-artifacts-dispatch"
-version = "0.3.1"
+version = "0.3.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/gateway/artifacts-spec/Cargo.toml
+++ b/gateway/artifacts-spec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "templar-gateway-artifacts-spec"
-version = "0.2.4"
+version = "0.2.5"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/gateway/client/CHANGELOG.md
+++ b/gateway/client/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.4](https://github.com/Templar-Protocol/contracts/compare/templar-gateway-client-v0.2.3...templar-gateway-client-v0.2.4) - 2026-09-01
+
+### Fixed
+
+- *(gateway)* settle a transaction the chain never recorded (ENG-477) ([#611](https://github.com/Templar-Protocol/contracts/pull/611))
+
 ## [0.2.1](https://github.com/Templar-Protocol/contracts/compare/templar-gateway-client-v0.2.0...templar-gateway-client-v0.2.1) - 2026-08-07
 
 ### Added

--- a/gateway/client/Cargo.toml
+++ b/gateway/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "templar-gateway-client"
-version = "0.2.3"
+version = "0.2.4"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/gateway/core/CHANGELOG.md
+++ b/gateway/core/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/Templar-Protocol/contracts/compare/templar-gateway-core-v0.4.1...templar-gateway-core-v0.5.0) - 2026-09-01
+
+### Added
+
+- *(gateway)* [**breaking**] validate registry init args against ABI (ENG-463) ([#607](https://github.com/Templar-Protocol/contracts/pull/607))
+- *(manager)* add guarded storage patch plans (ENG-652) ([#609](https://github.com/Templar-Protocol/contracts/pull/609))
+
+### Fixed
+
+- *(gateway)* settle a transaction the chain never recorded (ENG-477) ([#611](https://github.com/Templar-Protocol/contracts/pull/611))
+- *(manager)* harden patch dry-run replay (ENG-653) ([#612](https://github.com/Templar-Protocol/contracts/pull/612))
+- *(gateway)* ask the chain what it has, not what it will have (ENG-674) ([#613](https://github.com/Templar-Protocol/contracts/pull/613))
+
 ## [0.4.1](https://github.com/Templar-Protocol/contracts/compare/templar-gateway-core-v0.4.0...templar-gateway-core-v0.4.1) - 2026-08-25
 
 ### Added

--- a/gateway/core/Cargo.toml
+++ b/gateway/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "templar-gateway-core"
-version = "0.4.1"
+version = "0.5.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/gateway/methods-dispatch/CHANGELOG.md
+++ b/gateway/methods-dispatch/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/Templar-Protocol/contracts/compare/templar-gateway-methods-dispatch-v0.4.1...templar-gateway-methods-dispatch-v0.5.0) - 2026-09-01
+
+### Added
+
+- *(gateway)* [**breaking**] validate registry init args against ABI (ENG-463) ([#607](https://github.com/Templar-Protocol/contracts/pull/607))
+- *(manager)* add guarded storage patch plans (ENG-652) ([#609](https://github.com/Templar-Protocol/contracts/pull/609))
+- *(market)* migrate v1 markets to proxy oracles ([#614](https://github.com/Templar-Protocol/contracts/pull/614))
+
 ## [0.4.1](https://github.com/Templar-Protocol/contracts/compare/templar-gateway-methods-dispatch-v0.4.0...templar-gateway-methods-dispatch-v0.4.1) - 2026-08-25
 
 ### Added

--- a/gateway/methods-dispatch/Cargo.toml
+++ b/gateway/methods-dispatch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "templar-gateway-methods-dispatch"
-version = "0.4.1"
+version = "0.5.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/gateway/methods-spec/CHANGELOG.md
+++ b/gateway/methods-spec/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/Templar-Protocol/contracts/compare/templar-gateway-methods-spec-v0.4.1...templar-gateway-methods-spec-v0.5.0) - 2026-09-01
+
+### Added
+
+- *(gateway)* [**breaking**] validate registry init args against ABI (ENG-463) ([#607](https://github.com/Templar-Protocol/contracts/pull/607))
+- *(manager)* add guarded storage patch plans (ENG-652) ([#609](https://github.com/Templar-Protocol/contracts/pull/609))
+
 ## [0.4.1](https://github.com/Templar-Protocol/contracts/compare/templar-gateway-methods-spec-v0.4.0...templar-gateway-methods-spec-v0.4.1) - 2026-08-25
 
 ### Added

--- a/gateway/methods-spec/Cargo.toml
+++ b/gateway/methods-spec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "templar-gateway-methods-spec"
-version = "0.4.1"
+version = "0.5.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/gateway/oracle-updates-dispatch/Cargo.toml
+++ b/gateway/oracle-updates-dispatch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "templar-gateway-oracle-updates-dispatch"
-version = "0.2.2"
+version = "0.2.3"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/gateway/oracle-updates-spec/Cargo.toml
+++ b/gateway/oracle-updates-spec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "templar-gateway-oracle-updates-spec"
-version = "0.2.2"
+version = "0.2.3"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/gateway/runtime/Cargo.toml
+++ b/gateway/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "templar-gateway-runtime"
-version = "0.2.2"
+version = "0.2.3"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/gateway/sandbox/CHANGELOG.md
+++ b/gateway/sandbox/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/Templar-Protocol/contracts/releases/tag/templar-sandbox-v0.1.0) - 2026-09-01
+
+### Fixed
+
+- *(manager)* harden patch dry-run replay (ENG-653) ([#612](https://github.com/Templar-Protocol/contracts/pull/612))

--- a/gateway/store/CHANGELOG.md
+++ b/gateway/store/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.3](https://github.com/Templar-Protocol/contracts/compare/templar-gateway-store-v0.2.2...templar-gateway-store-v0.2.3) - 2026-09-01
+
+### Fixed
+
+- *(gateway)* settle a transaction the chain never recorded (ENG-477) ([#611](https://github.com/Templar-Protocol/contracts/pull/611))
+- *(gateway)* ask the chain what it has, not what it will have (ENG-674) ([#613](https://github.com/Templar-Protocol/contracts/pull/613))
+
 ## [0.2.0](https://github.com/Templar-Protocol/contracts/compare/templar-gateway-store-v0.1.2...templar-gateway-store-v0.2.0) - 2026-08-04
 
 ### Added

--- a/gateway/store/Cargo.toml
+++ b/gateway/store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "templar-gateway-store"
-version = "0.2.2"
+version = "0.2.3"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/gateway/types/CHANGELOG.md
+++ b/gateway/types/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/Templar-Protocol/contracts/compare/templar-gateway-types-v0.3.1...templar-gateway-types-v0.4.0) - 2026-09-01
+
+### Added
+
+- *(gateway)* [**breaking**] validate registry init args against ABI (ENG-463) ([#607](https://github.com/Templar-Protocol/contracts/pull/607))
+- *(manager)* add guarded storage patch plans (ENG-652) ([#609](https://github.com/Templar-Protocol/contracts/pull/609))
+
+### Fixed
+
+- *(manager)* harden patch dry-run replay (ENG-653) ([#612](https://github.com/Templar-Protocol/contracts/pull/612))
+
 ## [0.3.1](https://github.com/Templar-Protocol/contracts/compare/templar-gateway-types-v0.3.0...templar-gateway-types-v0.3.1) - 2026-08-25
 
 ### Added

--- a/gateway/types/Cargo.toml
+++ b/gateway/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "templar-gateway-types"
-version = "0.3.1"
+version = "0.4.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/service/accumulator/Cargo.toml
+++ b/service/accumulator/Cargo.toml
@@ -4,7 +4,7 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
-version = "0.1.6"
+version = "0.1.7"
 
 [[bin]]
 name = "accumulator"

--- a/service/funding-bridge/Cargo.toml
+++ b/service/funding-bridge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "templar-funding-bridge"
-version = "0.1.6"
+version = "0.1.7"
 edition.workspace = true
 rust-version.workspace = true
 repository.workspace = true

--- a/service/gateway/CHANGELOG.md
+++ b/service/gateway/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/Templar-Protocol/contracts/compare/templar-gateway-service-v0.5.1...templar-gateway-service-v0.6.0) - 2026-09-01
+
+### Added
+
+- *(gateway)* [**breaking**] validate registry init args against ABI (ENG-463) ([#607](https://github.com/Templar-Protocol/contracts/pull/607))
+
+### Fixed
+
+- *(gateway)* settle a transaction the chain never recorded (ENG-477) ([#611](https://github.com/Templar-Protocol/contracts/pull/611))
+
 ## [0.5.1](https://github.com/Templar-Protocol/contracts/compare/templar-gateway-service-v0.5.0...templar-gateway-service-v0.5.1) - 2026-08-25
 
 ### Added

--- a/service/gateway/Cargo.toml
+++ b/service/gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "templar-gateway-service"
-version = "0.5.1"
+version = "0.6.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/service/liquidator/Cargo.toml
+++ b/service/liquidator/Cargo.toml
@@ -4,7 +4,7 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
-version = "0.1.6"
+version = "0.1.7"
 
 [lib]
 path = "src/liquidator.rs"

--- a/service/relayer/CHANGELOG.md
+++ b/service/relayer/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/Templar-Protocol/contracts/compare/templar-relayer-v0.3.1...templar-relayer-v0.4.0) - 2026-09-01
+
+### Added
+
+- *(gateway)* [**breaking**] validate registry init args against ABI (ENG-463) ([#607](https://github.com/Templar-Protocol/contracts/pull/607))
+
 ## [0.3.0](https://github.com/Templar-Protocol/contracts/compare/templar-relayer-v0.2.1...templar-relayer-v0.3.0) - 2026-08-24
 
 ### Added

--- a/service/relayer/Cargo.toml
+++ b/service/relayer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "templar-relayer"
-version = "0.3.1"
+version = "0.4.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/tools/harvest-static-yield/Cargo.toml
+++ b/tools/harvest-static-yield/Cargo.toml
@@ -4,7 +4,7 @@ license.workspace = true
 repository.workspace = true
 edition.workspace = true
 rust-version.workspace = true
-version = "0.1.6"
+version = "0.1.7"
 
 [dependencies]
 anyhow.workspace = true

--- a/tools/manager/CHANGELOG.md
+++ b/tools/manager/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/Templar-Protocol/contracts/compare/templar-manager-v0.5.1...templar-manager-v0.6.0) - 2026-09-01
+
+### Added
+
+- *(gateway)* [**breaking**] validate registry init args against ABI (ENG-463) ([#607](https://github.com/Templar-Protocol/contracts/pull/607))
+- *(manager)* add guarded storage patch plans (ENG-652) ([#609](https://github.com/Templar-Protocol/contracts/pull/609))
+- *(market)* migrate v1 markets to proxy oracles ([#614](https://github.com/Templar-Protocol/contracts/pull/614))
+
+### Fixed
+
+- *(manager)* harden patch dry-run replay (ENG-653) ([#612](https://github.com/Templar-Protocol/contracts/pull/612))
+- *(ci)* route the patch dry-run replay to the node gate ([#616](https://github.com/Templar-Protocol/contracts/pull/616))
+- *(manager)* stabilize patch replay test ([#617](https://github.com/Templar-Protocol/contracts/pull/617))
+- *(manager)* isolate patch replay sandbox ([#618](https://github.com/Templar-Protocol/contracts/pull/618))
+
 ## [0.5.1](https://github.com/Templar-Protocol/contracts/compare/templar-manager-v0.5.0...templar-manager-v0.5.1) - 2026-08-25
 
 ### Added

--- a/tools/manager/Cargo.toml
+++ b/tools/manager/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "templar-manager"
-version = "0.5.1"
+version = "0.6.0"
 edition.workspace = true
 rust-version.workspace = true
 repository.workspace = true

--- a/tools/tools-common/Cargo.toml
+++ b/tools/tools-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "templar-tools-common"
-version = "0.2.2"
+version = "0.2.3"
 edition.workspace = true
 rust-version.workspace = true
 repository.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `templar-gateway-types`: 0.3.1 -> 0.4.0
* `templar-gateway-core`: 0.4.1 -> 0.5.0
* `templar-gateway-methods-spec`: 0.4.1 -> 0.5.0
* `templar-gateway-methods-dispatch`: 0.4.1 -> 0.5.0
* `templar-gateway-store`: 0.2.2 -> 0.2.3
* `templar-gateway-client`: 0.2.3 -> 0.2.4
* `templar-sandbox`: 0.1.0
* `templar-relayer`: 0.3.1 -> 0.4.0
* `templar-registry-contract`: 2.0.1 -> 3.0.0
* `templar-manager`: 0.5.1 -> 0.6.0
* `templar-gateway-service`: 0.5.1 -> 0.6.0
* `templar-gateway-artifacts-spec`: 0.2.4 -> 0.2.5
* `templar-gateway-artifacts-dispatch`: 0.3.1 -> 0.3.2
* `templar-gateway-runtime`: 0.2.2 -> 0.2.3
* `templar-gateway-oracle-updates-spec`: 0.2.2 -> 0.2.3
* `templar-gateway-oracle-updates-dispatch`: 0.2.2 -> 0.2.3
* `templar-market-contract`: 1.5.2 -> 1.5.3
* `templar-patch-state-contract`: 0.1.0 -> 0.1.1
* `templar-proxy-oracle-near-contract`: 0.4.4 -> 0.4.5
* `templar-proxy-oracle-near-governance-contract`: 0.3.3 -> 0.3.4
* `templar-lst-oracle-contract`: 1.2.5 -> 1.2.6
* `harvest-static-yield`: 0.1.6 -> 0.1.7
* `templar-tools-common`: 0.2.2 -> 0.2.3
* `templar-accumulator`: 0.1.6 -> 0.1.7
* `templar-funding-bridge`: 0.1.6 -> 0.1.7
* `templar-liquidator`: 0.1.6 -> 0.1.7

<details><summary><i><b>Changelog</b></i></summary><p>

## `templar-gateway-types`

<blockquote>

## [0.4.0](https://github.com/Templar-Protocol/contracts/compare/templar-gateway-types-v0.3.1...templar-gateway-types-v0.4.0) - 2026-09-01

### Added

- *(gateway)* [**breaking**] validate registry init args against ABI (ENG-463) ([#607](https://github.com/Templar-Protocol/contracts/pull/607))
- *(manager)* add guarded storage patch plans (ENG-652) ([#609](https://github.com/Templar-Protocol/contracts/pull/609))

### Fixed

- *(manager)* harden patch dry-run replay (ENG-653) ([#612](https://github.com/Templar-Protocol/contracts/pull/612))
</blockquote>

## `templar-gateway-core`

<blockquote>

## [0.5.0](https://github.com/Templar-Protocol/contracts/compare/templar-gateway-core-v0.4.1...templar-gateway-core-v0.5.0) - 2026-09-01

### Added

- *(gateway)* [**breaking**] validate registry init args against ABI (ENG-463) ([#607](https://github.com/Templar-Protocol/contracts/pull/607))
- *(manager)* add guarded storage patch plans (ENG-652) ([#609](https://github.com/Templar-Protocol/contracts/pull/609))

### Fixed

- *(gateway)* settle a transaction the chain never recorded (ENG-477) ([#611](https://github.com/Templar-Protocol/contracts/pull/611))
- *(manager)* harden patch dry-run replay (ENG-653) ([#612](https://github.com/Templar-Protocol/contracts/pull/612))
- *(gateway)* ask the chain what it has, not what it will have (ENG-674) ([#613](https://github.com/Templar-Protocol/contracts/pull/613))
</blockquote>

## `templar-gateway-methods-spec`

<blockquote>

## [0.5.0](https://github.com/Templar-Protocol/contracts/compare/templar-gateway-methods-spec-v0.4.1...templar-gateway-methods-spec-v0.5.0) - 2026-09-01

### Added

- *(gateway)* [**breaking**] validate registry init args against ABI (ENG-463) ([#607](https://github.com/Templar-Protocol/contracts/pull/607))
- *(manager)* add guarded storage patch plans (ENG-652) ([#609](https://github.com/Templar-Protocol/contracts/pull/609))
</blockquote>

## `templar-gateway-methods-dispatch`

<blockquote>

## [0.5.0](https://github.com/Templar-Protocol/contracts/compare/templar-gateway-methods-dispatch-v0.4.1...templar-gateway-methods-dispatch-v0.5.0) - 2026-09-01

### Added

- *(gateway)* [**breaking**] validate registry init args against ABI (ENG-463) ([#607](https://github.com/Templar-Protocol/contracts/pull/607))
- *(manager)* add guarded storage patch plans (ENG-652) ([#609](https://github.com/Templar-Protocol/contracts/pull/609))
- *(market)* migrate v1 markets to proxy oracles ([#614](https://github.com/Templar-Protocol/contracts/pull/614))
</blockquote>

## `templar-gateway-store`

<blockquote>

## [0.2.3](https://github.com/Templar-Protocol/contracts/compare/templar-gateway-store-v0.2.2...templar-gateway-store-v0.2.3) - 2026-09-01

### Fixed

- *(gateway)* settle a transaction the chain never recorded (ENG-477) ([#611](https://github.com/Templar-Protocol/contracts/pull/611))
- *(gateway)* ask the chain what it has, not what it will have (ENG-674) ([#613](https://github.com/Templar-Protocol/contracts/pull/613))
</blockquote>

## `templar-gateway-client`

<blockquote>

## [0.2.4](https://github.com/Templar-Protocol/contracts/compare/templar-gateway-client-v0.2.3...templar-gateway-client-v0.2.4) - 2026-09-01

### Fixed

- *(gateway)* settle a transaction the chain never recorded (ENG-477) ([#611](https://github.com/Templar-Protocol/contracts/pull/611))
</blockquote>

## `templar-sandbox`

<blockquote>

## [0.1.0](https://github.com/Templar-Protocol/contracts/releases/tag/templar-sandbox-v0.1.0) - 2026-09-01

### Fixed

- *(manager)* harden patch dry-run replay (ENG-653) ([#612](https://github.com/Templar-Protocol/contracts/pull/612))
</blockquote>

## `templar-relayer`

<blockquote>

## [0.4.0](https://github.com/Templar-Protocol/contracts/compare/templar-relayer-v0.3.1...templar-relayer-v0.4.0) - 2026-09-01

### Added

- *(gateway)* [**breaking**] validate registry init args against ABI (ENG-463) ([#607](https://github.com/Templar-Protocol/contracts/pull/607))
</blockquote>

## `templar-registry-contract`

<blockquote>

## [3.0.0](https://github.com/Templar-Protocol/contracts/compare/templar-registry-contract-v2.0.1...templar-registry-contract-v3.0.0) - 2026-09-01

### Added

- *(gateway)* [**breaking**] validate registry init args against ABI (ENG-463) ([#607](https://github.com/Templar-Protocol/contracts/pull/607))
</blockquote>

## `templar-manager`

<blockquote>

## [0.6.0](https://github.com/Templar-Protocol/contracts/compare/templar-manager-v0.5.1...templar-manager-v0.6.0) - 2026-09-01

### Added

- *(gateway)* [**breaking**] validate registry init args against ABI (ENG-463) ([#607](https://github.com/Templar-Protocol/contracts/pull/607))
- *(manager)* add guarded storage patch plans (ENG-652) ([#609](https://github.com/Templar-Protocol/contracts/pull/609))
- *(market)* migrate v1 markets to proxy oracles ([#614](https://github.com/Templar-Protocol/contracts/pull/614))

### Fixed

- *(manager)* harden patch dry-run replay (ENG-653) ([#612](https://github.com/Templar-Protocol/contracts/pull/612))
- *(ci)* route the patch dry-run replay to the node gate ([#616](https://github.com/Templar-Protocol/contracts/pull/616))
- *(manager)* stabilize patch replay test ([#617](https://github.com/Templar-Protocol/contracts/pull/617))
- *(manager)* isolate patch replay sandbox ([#618](https://github.com/Templar-Protocol/contracts/pull/618))
</blockquote>

## `templar-gateway-service`

<blockquote>

## [0.6.0](https://github.com/Templar-Protocol/contracts/compare/templar-gateway-service-v0.5.1...templar-gateway-service-v0.6.0) - 2026-09-01

### Added

- *(gateway)* [**breaking**] validate registry init args against ABI (ENG-463) ([#607](https://github.com/Templar-Protocol/contracts/pull/607))

### Fixed

- *(gateway)* settle a transaction the chain never recorded (ENG-477) ([#611](https://github.com/Templar-Protocol/contracts/pull/611))
</blockquote>

## `templar-gateway-artifacts-spec`

<blockquote>

## [0.2.0](https://github.com/Templar-Protocol/contracts/compare/templar-gateway-artifacts-spec-v0.1.0...templar-gateway-artifacts-spec-v0.2.0) - 2026-08-03

### Added

- *(release)* [**breaking**] automate per-crate releases and version contract artifacts (ENG-522) ([#528](https://github.com/Templar-Protocol/contracts/pull/528))

### Documentation

- fix rustdoc warnings and gate them in CI ([#532](https://github.com/Templar-Protocol/contracts/pull/532))
</blockquote>

## `templar-gateway-artifacts-dispatch`

<blockquote>

## [0.3.0](https://github.com/Templar-Protocol/contracts/compare/templar-gateway-artifacts-dispatch-v0.2.2...templar-gateway-artifacts-dispatch-v0.3.0) - 2026-08-24

### Added

- *(registry)* [**breaking**] register an existing global contract by code hash (ENG-631) ([#596](https://github.com/Templar-Protocol/contracts/pull/596))
</blockquote>

## `templar-gateway-runtime`

<blockquote>

## [0.2.0](https://github.com/Templar-Protocol/contracts/compare/templar-gateway-runtime-v0.1.2...templar-gateway-runtime-v0.2.0) - 2026-08-04

### Added

- *(gateway-core)* [**breaking**] serialize the write path per access key (ENG-530) ([#561](https://github.com/Templar-Protocol/contracts/pull/561))
</blockquote>

## `templar-gateway-oracle-updates-spec`

<blockquote>

## [0.2.0](https://github.com/Templar-Protocol/contracts/compare/templar-gateway-oracle-updates-spec-v0.1.3...templar-gateway-oracle-updates-spec-v0.2.0) - 2026-08-07

### Added

- *(gateway)* [**breaking**] oracle.updatePyth fetches its own payload (ENG-462) ([#586](https://github.com/Templar-Protocol/contracts/pull/586))
</blockquote>

## `templar-gateway-oracle-updates-dispatch`

<blockquote>

## [0.2.0](https://github.com/Templar-Protocol/contracts/compare/templar-gateway-oracle-updates-dispatch-v0.1.3...templar-gateway-oracle-updates-dispatch-v0.2.0) - 2026-08-07

### Added

- *(gateway)* [**breaking**] oracle.updatePyth fetches its own payload (ENG-462) ([#586](https://github.com/Templar-Protocol/contracts/pull/586))
</blockquote>

## `templar-market-contract`

<blockquote>

## [1.5.1](https://github.com/Templar-Protocol/contracts/compare/templar-market-contract-v1.5.0...templar-market-contract-v1.5.1) - 2026-08-24

### Fixed

- *(proxy-oracle)* remediate Halborn findings ([#595](https://github.com/Templar-Protocol/contracts/pull/595))
</blockquote>

## `templar-patch-state-contract`

<blockquote>

## [0.1.0](https://github.com/Templar-Protocol/contracts/releases/tag/templar-patch-state-contract-v0.1.0) - 2026-08-25

### Added

- *(patch-state)* add atomic state-patching contract ([#604](https://github.com/Templar-Protocol/contracts/pull/604))
</blockquote>

## `templar-proxy-oracle-near-contract`

<blockquote>

## [0.4.4](https://github.com/Templar-Protocol/contracts/compare/templar-proxy-oracle-near-contract-v0.4.3...templar-proxy-oracle-near-contract-v0.4.4) - 2026-08-25

### Added

- *(manager)* gate proxy-oracle upgrades on a deployed-state preflight (ENG-648) ([#601](https://github.com/Templar-Protocol/contracts/pull/601))
</blockquote>

## `templar-proxy-oracle-near-governance-contract`

<blockquote>

## [0.3.3](https://github.com/Templar-Protocol/contracts/compare/templar-proxy-oracle-near-governance-contract-v0.3.2...templar-proxy-oracle-near-governance-contract-v0.3.3) - 2026-08-25

### Added

- *(manager)* gate proxy-oracle upgrades on a deployed-state preflight (ENG-648) ([#601](https://github.com/Templar-Protocol/contracts/pull/601))
</blockquote>

## `templar-lst-oracle-contract`

<blockquote>

## [1.2.2](https://github.com/Templar-Protocol/contracts/compare/templar-lst-oracle-contract-v1.2.1...templar-lst-oracle-contract-v1.2.2) - 2026-08-03

### Added

- *(release)* automate per-crate releases and version contract artifacts (ENG-522) ([#528](https://github.com/Templar-Protocol/contracts/pull/528))
</blockquote>

## `harvest-static-yield`

<blockquote>

## [0.1.1](https://github.com/Templar-Protocol/contracts/compare/harvest-static-yield-v0.1.0...harvest-static-yield-v0.1.1) - 2026-08-03

### Added

- *(release)* automate per-crate releases and version contract artifacts (ENG-522) ([#528](https://github.com/Templar-Protocol/contracts/pull/528))
</blockquote>

## `templar-tools-common`

<blockquote>

## [0.2.0](https://github.com/Templar-Protocol/contracts/compare/templar-tools-common-v0.1.3...templar-tools-common-v0.2.0) - 2026-08-07

### Changed

- *(tools-common)* [**breaking**] drop the unused NEAR client layer ([#579](https://github.com/Templar-Protocol/contracts/pull/579))
</blockquote>

## `templar-accumulator`

<blockquote>

## [0.1.1](https://github.com/Templar-Protocol/contracts/compare/templar-accumulator-v0.1.0...templar-accumulator-v0.1.1) - 2026-08-03

### Added

- *(release)* automate per-crate releases and version contract artifacts (ENG-522) ([#528](https://github.com/Templar-Protocol/contracts/pull/528))

### Documentation

- fix rustdoc warnings and gate them in CI ([#532](https://github.com/Templar-Protocol/contracts/pull/532))
</blockquote>

## `templar-funding-bridge`

<blockquote>

## [0.1.1](https://github.com/Templar-Protocol/contracts/compare/templar-funding-bridge-v0.1.0...templar-funding-bridge-v0.1.1) - 2026-08-03

### Added

- *(release)* automate per-crate releases and version contract artifacts (ENG-522) ([#528](https://github.com/Templar-Protocol/contracts/pull/528))

### Documentation

- fix rustdoc warnings and gate them in CI ([#532](https://github.com/Templar-Protocol/contracts/pull/532))
</blockquote>

## `templar-liquidator`

<blockquote>

## [0.1.4](https://github.com/Templar-Protocol/contracts/compare/templar-liquidator-v0.1.3...templar-liquidator-v0.1.4) - 2026-08-07

### Added

- *(gateway)* [**breaking**] oracle.updatePyth fetches its own payload (ENG-462) ([#586](https://github.com/Templar-Protocol/contracts/pull/586))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/610)
<!-- Reviewable:end -->
