### PR TITLE
fix(gateway): settle a transaction the chain never recorded (ENG-477)

### DIFF
--- a/gateway/client/src/lib.rs
+++ b/gateway/client/src/lib.rs
@@ -59,6 +59,7 @@ use templar_gateway_types::{
 /// idempotency/replay (an in-process [`MemoryStore`] by default).
 pub struct ClientBuilder {
     network: NetworkConfig,
+    archival_network: Option<NetworkConfig>,
     signers: HashMap<ManagedAccountId, PooledSigner>,
     store: SharedOperationStore,
     finality_policy: FinalityPolicy,
@@ -99,6 +100,18 @@ impl ClientBuilder {
         self
     }
 
+    /// Set the archival RPC endpoint reconciliation consults when the primary
+    /// has no record of a transaction. A primary node garbage collects outcomes,
+    /// so without an endpoint that retains history a transaction which did
+    /// execute is indistinguishable from one that never did — and its operation
+    /// stays in flight rather than settling. Must point at a genuinely archival
+    /// node.
+    #[must_use]
+    pub fn archival_network(mut self, archival_network: Option<NetworkConfig>) -> Self {
+        self.archival_network = archival_network;
+        self
+    }
+
     /// Set the transaction-wait and state-query policy. Defaults to
     /// [`FinalityPolicy::Executed`].
     #[must_use]
@@ -121,8 +134,11 @@ impl ClientBuilder {
         ));
         let signer_account_ids = self.signers.keys().cloned().collect();
         let signer = NearTransactionSigner::new(self.network.clone(), self.signers);
-        let executor =
-            NearOperationExecutor::with_finality_policy(self.network, self.finality_policy);
+        let executor = NearOperationExecutor::with_finality_policy(
+            self.network,
+            self.archival_network,
+            self.finality_policy,
+        );
         let driver = OperationDriver::new(self.store, Arc::new(signer), Arc::new(executor));
         Ok((context, driver, signer_account_ids))
     }
@@ -176,6 +192,7 @@ impl Client {
     pub fn builder(network: NetworkConfig) -> ClientBuilder {
         ClientBuilder {
             network,
+            archival_network: None,
             signers: HashMap::new(),
             store: Arc::new(MemoryStore::new()),
             finality_policy: FinalityPolicy::default(),

--- a/gateway/client/src/network.rs
+++ b/gateway/client/src/network.rs
@@ -2,7 +2,7 @@
 
 use std::fmt;
 
-use near_api::NetworkConfig;
+use near_api::{NetworkConfig, RPCEndpoint};
 use url::Url;
 
 /// Pyth's public Hermes endpoints. A VAA is only accepted by the Pyth receiver whose
@@ -75,7 +75,8 @@ impl fmt::Display for Network {
 /// parameter is extracted from the URL and moved to the header.
 pub struct NetworkConfigBuilder {
     network_name: String,
-    rpc_url: url::Url,
+    rpc_url: Url,
+    archival_rpc_url: Option<Url>,
     api_key: Option<String>,
 }
 
@@ -92,6 +93,7 @@ impl NetworkConfigBuilder {
                 .rpc_url()
                 .parse()
                 .expect("Network::rpc_url must be a valid URL"),
+            archival_rpc_url: None,
             api_key: None,
         }
     }
@@ -99,10 +101,11 @@ impl NetworkConfigBuilder {
     /// Start from an explicit network name and pre-parsed RPC URL, for consumers
     /// that don't select via the [`Network`] enum.
     #[must_use]
-    pub fn from_url(name: impl Into<String>, rpc_url: url::Url) -> Self {
+    pub fn from_url(name: impl Into<String>, rpc_url: Url) -> Self {
         Self {
             network_name: name.into(),
             rpc_url,
+            archival_rpc_url: None,
             api_key: None,
         }
     }
@@ -122,6 +125,16 @@ impl NetworkConfigBuilder {
         Ok(self)
     }
 
+    /// Add an archival RPC endpoint, tried after the primary. Reconciling a
+    /// long-submitted transaction needs one: a regular node garbage collects the
+    /// outcome and then answers `UNKNOWN_TRANSACTION` for a transaction that did
+    /// execute.
+    #[must_use]
+    pub fn archival_rpc_url(mut self, archival_rpc_url: Option<Url>) -> Self {
+        self.archival_rpc_url = archival_rpc_url;
+        self
+    }
+
     /// Set the RPC API key, sent as an `Authorization` header. Takes precedence
     /// over a key embedded in the URL; `None` falls back to that embedded key.
     ///
@@ -135,53 +148,57 @@ impl NetworkConfigBuilder {
         self
     }
 
-    /// Resolve the configuration, moving any API key onto the endpoint header.
+    /// Resolve the configuration, moving any API key onto the endpoint headers.
     #[must_use]
-    pub fn build(mut self) -> NetworkConfig {
-        let embedded_key = self.take_embedded_api_key();
-
-        let mut network = NetworkConfig::from_rpc_url(&self.network_name, self.rpc_url);
-        if let Some(api_key) = self.api_key.or(embedded_key) {
-            network.rpc_endpoints = network
-                .rpc_endpoints
-                .into_iter()
-                .map(|endpoint| endpoint.with_api_key(api_key.clone()))
-                .collect();
-        }
-
+    pub fn build(self) -> NetworkConfig {
+        let mut network = NetworkConfig::from_rpc_url(&self.network_name, self.rpc_url.clone());
+        // Primary first: near_api and the gateway's own reconciliation both walk
+        // this list in order, so the archival node only answers what the primary
+        // could not.
+        network.rpc_endpoints = std::iter::once(self.rpc_url)
+            .chain(self.archival_rpc_url)
+            .map(|url| endpoint(url, self.api_key.as_deref()))
+            .collect();
         network
     }
+}
 
-    /// Remove and return an `apiKey` query parameter from the RPC URL, leaving
-    /// any other query parameters intact.
-    fn take_embedded_api_key(&mut self) -> Option<String> {
-        let mut api_key = None;
-        let remaining: Vec<(String, String)> = self
-            .rpc_url
-            .query_pairs()
-            .filter_map(|(key, value)| {
-                if key == "apiKey" {
-                    api_key = Some(value.into_owned());
-                    None
-                } else {
-                    Some((key.into_owned(), value.into_owned()))
-                }
-            })
-            .collect();
-
-        if api_key.is_some() {
-            if remaining.is_empty() {
-                self.rpc_url.set_query(None);
-            } else {
-                self.rpc_url
-                    .query_pairs_mut()
-                    .clear()
-                    .extend_pairs(remaining);
-            }
-        }
-
-        api_key
+/// Build an endpoint, moving any API key onto its header. An explicitly
+/// configured key takes precedence over one embedded in this URL.
+fn endpoint(mut url: Url, explicit_api_key: Option<&str>) -> RPCEndpoint {
+    let embedded_api_key = take_embedded_api_key(&mut url);
+    let endpoint = RPCEndpoint::new(url);
+    match explicit_api_key.map(str::to_owned).or(embedded_api_key) {
+        Some(api_key) => endpoint.with_api_key(api_key),
+        None => endpoint,
     }
+}
+
+/// Remove and return an `apiKey` query parameter from `rpc_url`, leaving any
+/// other query parameters intact.
+fn take_embedded_api_key(rpc_url: &mut Url) -> Option<String> {
+    let mut api_key = None;
+    let remaining: Vec<(String, String)> = rpc_url
+        .query_pairs()
+        .filter_map(|(key, value)| {
+            if key == "apiKey" {
+                api_key = Some(value.into_owned());
+                None
+            } else {
+                Some((key.into_owned(), value.into_owned()))
+            }
+        })
+        .collect();
+
+    if api_key.is_some() {
+        if remaining.is_empty() {
+            rpc_url.set_query(None);
+        } else {
+            rpc_url.query_pairs_mut().clear().extend_pairs(remaining);
+        }
+    }
+
+    api_key
 }
 
 #[cfg(test)]
@@ -199,6 +216,69 @@ mod tests {
             Network::Testnet.hermes_url().as_str(),
             "https://hermes-beta.pyth.network/"
         );
+    }
+
+    /// Order is the contract: reconciliation walks endpoints in sequence, so the
+    /// archival node must only answer what the primary could not.
+    #[test]
+    fn archival_endpoint_is_appended_after_the_primary() {
+        let network = NetworkConfigBuilder::from_url(
+            "mainnet",
+            "https://rpc.mainnet.fastnear.com/".parse().unwrap(),
+        )
+        .archival_rpc_url(Some(
+            "https://archival.mainnet.fastnear.com/?apiKey=ARCHIVAL"
+                .parse()
+                .unwrap(),
+        ))
+        .build();
+
+        let urls: Vec<&str> = network
+            .rpc_endpoints
+            .iter()
+            .map(|endpoint| endpoint.url.as_str())
+            .collect();
+        assert_eq!(
+            urls,
+            [
+                "https://rpc.mainnet.fastnear.com/",
+                "https://archival.mainnet.fastnear.com/"
+            ]
+        );
+        assert_eq!(
+            network.rpc_endpoints[1].bearer_header.as_deref(),
+            Some("Bearer ARCHIVAL")
+        );
+    }
+
+    /// A key configured for the deployment has to reach the archival endpoint
+    /// too, or a keyed provider answers 401 exactly when reconciliation needs it.
+    #[test]
+    fn explicit_api_key_reaches_the_archival_endpoint() {
+        let network = NetworkConfigBuilder::from_url(
+            "mainnet",
+            "https://rpc.mainnet.fastnear.com/".parse().unwrap(),
+        )
+        .archival_rpc_url(Some(
+            "https://archival.mainnet.fastnear.com/".parse().unwrap(),
+        ))
+        .api_key(Some("SECRET".to_owned()))
+        .build();
+
+        for endpoint in &network.rpc_endpoints {
+            assert_eq!(endpoint.bearer_header.as_deref(), Some("Bearer SECRET"));
+        }
+    }
+
+    #[test]
+    fn no_archival_endpoint_leaves_a_single_endpoint() {
+        let network = NetworkConfigBuilder::from_url(
+            "mainnet",
+            "https://rpc.mainnet.fastnear.com/".parse().unwrap(),
+        )
+        .build();
+
+        assert_eq!(network.rpc_endpoints.len(), 1);
     }
 
     #[test]

--- a/gateway/client/src/network.rs
+++ b/gateway/client/src/network.rs
@@ -2,7 +2,7 @@
 
 use std::fmt;
 
-use near_api::{NetworkConfig, RPCEndpoint};
+use near_api::NetworkConfig;
 use url::Url;
 
 /// Pyth's public Hermes endpoints. A VAA is only accepted by the Pyth receiver whose
@@ -75,8 +75,7 @@ impl fmt::Display for Network {
 /// parameter is extracted from the URL and moved to the header.
 pub struct NetworkConfigBuilder {
     network_name: String,
-    rpc_url: Url,
-    archival_rpc_url: Option<Url>,
+    rpc_url: url::Url,
     api_key: Option<String>,
 }
 
@@ -93,7 +92,6 @@ impl NetworkConfigBuilder {
                 .rpc_url()
                 .parse()
                 .expect("Network::rpc_url must be a valid URL"),
-            archival_rpc_url: None,
             api_key: None,
         }
     }
@@ -101,11 +99,10 @@ impl NetworkConfigBuilder {
     /// Start from an explicit network name and pre-parsed RPC URL, for consumers
     /// that don't select via the [`Network`] enum.
     #[must_use]
-    pub fn from_url(name: impl Into<String>, rpc_url: Url) -> Self {
+    pub fn from_url(name: impl Into<String>, rpc_url: url::Url) -> Self {
         Self {
             network_name: name.into(),
             rpc_url,
-            archival_rpc_url: None,
             api_key: None,
         }
     }
@@ -125,16 +122,6 @@ impl NetworkConfigBuilder {
         Ok(self)
     }
 
-    /// Add an archival RPC endpoint, tried after the primary. Reconciling a
-    /// long-submitted transaction needs one: a regular node garbage collects the
-    /// outcome and then answers `UNKNOWN_TRANSACTION` for a transaction that did
-    /// execute.
-    #[must_use]
-    pub fn archival_rpc_url(mut self, archival_rpc_url: Option<Url>) -> Self {
-        self.archival_rpc_url = archival_rpc_url;
-        self
-    }
-
     /// Set the RPC API key, sent as an `Authorization` header. Takes precedence
     /// over a key embedded in the URL; `None` falls back to that embedded key.
     ///
@@ -148,57 +135,53 @@ impl NetworkConfigBuilder {
         self
     }
 
-    /// Resolve the configuration, moving any API key onto the endpoint headers.
+    /// Resolve the configuration, moving any API key onto the endpoint header.
     #[must_use]
-    pub fn build(self) -> NetworkConfig {
-        let mut network = NetworkConfig::from_rpc_url(&self.network_name, self.rpc_url.clone());
-        // Primary first: near_api and the gateway's own reconciliation both walk
-        // this list in order, so the archival node only answers what the primary
-        // could not.
-        network.rpc_endpoints = std::iter::once(self.rpc_url)
-            .chain(self.archival_rpc_url)
-            .map(|url| endpoint(url, self.api_key.as_deref()))
-            .collect();
+    pub fn build(mut self) -> NetworkConfig {
+        let embedded_key = self.take_embedded_api_key();
+
+        let mut network = NetworkConfig::from_rpc_url(&self.network_name, self.rpc_url);
+        if let Some(api_key) = self.api_key.or(embedded_key) {
+            network.rpc_endpoints = network
+                .rpc_endpoints
+                .into_iter()
+                .map(|endpoint| endpoint.with_api_key(api_key.clone()))
+                .collect();
+        }
+
         network
     }
-}
 
-/// Build an endpoint, moving any API key onto its header. An explicitly
-/// configured key takes precedence over one embedded in this URL.
-fn endpoint(mut url: Url, explicit_api_key: Option<&str>) -> RPCEndpoint {
-    let embedded_api_key = take_embedded_api_key(&mut url);
-    let endpoint = RPCEndpoint::new(url);
-    match explicit_api_key.map(str::to_owned).or(embedded_api_key) {
-        Some(api_key) => endpoint.with_api_key(api_key),
-        None => endpoint,
-    }
-}
+    /// Remove and return an `apiKey` query parameter from the RPC URL, leaving
+    /// any other query parameters intact.
+    fn take_embedded_api_key(&mut self) -> Option<String> {
+        let mut api_key = None;
+        let remaining: Vec<(String, String)> = self
+            .rpc_url
+            .query_pairs()
+            .filter_map(|(key, value)| {
+                if key == "apiKey" {
+                    api_key = Some(value.into_owned());
+                    None
+                } else {
+                    Some((key.into_owned(), value.into_owned()))
+                }
+            })
+            .collect();
 
-/// Remove and return an `apiKey` query parameter from `rpc_url`, leaving any
-/// other query parameters intact.
-fn take_embedded_api_key(rpc_url: &mut Url) -> Option<String> {
-    let mut api_key = None;
-    let remaining: Vec<(String, String)> = rpc_url
-        .query_pairs()
-        .filter_map(|(key, value)| {
-            if key == "apiKey" {
-                api_key = Some(value.into_owned());
-                None
+        if api_key.is_some() {
+            if remaining.is_empty() {
+                self.rpc_url.set_query(None);
             } else {
-                Some((key.into_owned(), value.into_owned()))
+                self.rpc_url
+                    .query_pairs_mut()
+                    .clear()
+                    .extend_pairs(remaining);
             }
-        })
-        .collect();
-
-    if api_key.is_some() {
-        if remaining.is_empty() {
-            rpc_url.set_query(None);
-        } else {
-            rpc_url.query_pairs_mut().clear().extend_pairs(remaining);
         }
-    }
 
-    api_key
+        api_key
+    }
 }
 
 #[cfg(test)]
@@ -216,69 +199,6 @@ mod tests {
             Network::Testnet.hermes_url().as_str(),
             "https://hermes-beta.pyth.network/"
         );
-    }
-
-    /// Order is the contract: reconciliation walks endpoints in sequence, so the
-    /// archival node must only answer what the primary could not.
-    #[test]
-    fn archival_endpoint_is_appended_after_the_primary() {
-        let network = NetworkConfigBuilder::from_url(
-            "mainnet",
-            "https://rpc.mainnet.fastnear.com/".parse().unwrap(),
-        )
-        .archival_rpc_url(Some(
-            "https://archival.mainnet.fastnear.com/?apiKey=ARCHIVAL"
-                .parse()
-                .unwrap(),
-        ))
-        .build();
-
-        let urls: Vec<&str> = network
-            .rpc_endpoints
-            .iter()
-            .map(|endpoint| endpoint.url.as_str())
-            .collect();
-        assert_eq!(
-            urls,
-            [
-                "https://rpc.mainnet.fastnear.com/",
-                "https://archival.mainnet.fastnear.com/"
-            ]
-        );
-        assert_eq!(
-            network.rpc_endpoints[1].bearer_header.as_deref(),
-            Some("Bearer ARCHIVAL")
-        );
-    }
-
-    /// A key configured for the deployment has to reach the archival endpoint
-    /// too, or a keyed provider answers 401 exactly when reconciliation needs it.
-    #[test]
-    fn explicit_api_key_reaches_the_archival_endpoint() {
-        let network = NetworkConfigBuilder::from_url(
-            "mainnet",
-            "https://rpc.mainnet.fastnear.com/".parse().unwrap(),
-        )
-        .archival_rpc_url(Some(
-            "https://archival.mainnet.fastnear.com/".parse().unwrap(),
-        ))
-        .api_key(Some("SECRET".to_owned()))
-        .build();
-
-        for endpoint in &network.rpc_endpoints {
-            assert_eq!(endpoint.bearer_header.as_deref(), Some("Bearer SECRET"));
-        }
-    }
-
-    #[test]
-    fn no_archival_endpoint_leaves_a_single_endpoint() {
-        let network = NetworkConfigBuilder::from_url(
-            "mainnet",
-            "https://rpc.mainnet.fastnear.com/".parse().unwrap(),
-        )
-        .build();
-
-        assert_eq!(network.rpc_endpoints.len(), 1);
     }
 
     #[test]

--- a/gateway/core/src/error.rs
+++ b/gateway/core/src/error.rs
@@ -24,8 +24,6 @@ pub enum GatewayError {
     InvalidSignerKey(String),
     #[error("near transaction failed: {0}")]
     NearTransaction(String),
-    #[error("transaction not found on chain")]
-    TransactionNotFound,
     #[error("external service failed: {0}")]
     ExternalService(String),
     #[error("unsupported feature: {0}")]

--- a/gateway/core/src/executor.rs
+++ b/gateway/core/src/executor.rs
@@ -132,8 +132,8 @@ pub struct NearOperationExecutor {
     /// missing transaction can never be confirmed missing — see
     /// [`TransactionRecord::Unconfirmed`].
     archival_status_network: Option<NetworkConfig>,
-    /// One single-endpoint, single-attempt view of `network` per endpoint, so a
-    /// status query can be addressed to each in turn.
+    /// One single-endpoint view of `network` per endpoint, so a status query can
+    /// be addressed to each in turn.
     status_query_networks: Vec<NetworkConfig>,
     finality_policy: FinalityPolicy,
 }
@@ -156,32 +156,18 @@ impl NearOperationExecutor {
         let status_query_networks = network
             .rpc_endpoints
             .iter()
-            .map(|endpoint| NetworkConfig {
-                rpc_endpoints: vec![endpoint.clone().with_retries(1)],
-                ..network.clone()
+            .map(|endpoint| {
+                single_attempt(NetworkConfig {
+                    rpc_endpoints: vec![endpoint.clone()],
+                    ..network.clone()
+                })
             })
             .collect();
         Self {
             network,
             status_query_networks,
-            archival_status_network: archival_network
-                .as_ref()
-                .map(|network| Self::status_query(network)),
+            archival_status_network: archival_network.map(single_attempt),
             finality_policy,
-        }
-    }
-
-    /// A single-attempt view of `network`. near_api treats `UNKNOWN_TRANSACTION`
-    /// as retryable and would sleep through its whole backoff schedule before the
-    /// answer could be classified, on every orphan of every recovery sweep.
-    fn status_query(network: &NetworkConfig) -> NetworkConfig {
-        NetworkConfig {
-            rpc_endpoints: network
-                .rpc_endpoints
-                .iter()
-                .map(|endpoint| endpoint.clone().with_retries(1))
-                .collect(),
-            ..network.clone()
         }
     }
 
@@ -343,6 +329,19 @@ impl ExecuteOperation for NearOperationExecutor {
             },
         )
     }
+}
+
+/// A view of `network` that tries each endpoint once. near_api treats
+/// `UNKNOWN_TRANSACTION` as retryable and would otherwise sleep through its whole
+/// backoff schedule before the answer could be classified — on every orphan of
+/// every recovery sweep.
+fn single_attempt(mut network: NetworkConfig) -> NetworkConfig {
+    network.rpc_endpoints = network
+        .rpc_endpoints
+        .into_iter()
+        .map(|endpoint| endpoint.with_retries(1))
+        .collect();
+    network
 }
 
 #[allow(

--- a/gateway/core/src/executor.rs
+++ b/gateway/core/src/executor.rs
@@ -18,7 +18,7 @@ use near_api::{
             PrepopulateTransaction, SignedTransaction,
         },
     },
-    PublicKey, SecretKey,
+    SecretKey,
 };
 use std::collections::HashMap;
 
@@ -39,14 +39,6 @@ pub trait SignTransaction: Send + Sync {
         &self,
         signer_account_id: &ManagedAccountId,
     ) -> GatewayResult<SigningKeyLease>;
-
-    /// Lease the specific key a transaction was already signed with, or `None`
-    /// when this process holds no such key.
-    async fn lease_signing_key(
-        &self,
-        signer_account_id: &ManagedAccountId,
-        public_key: &PublicKey,
-    ) -> Option<SigningKeyLease>;
 
     /// Signs with `lease`'s key and allocates that key's nonce, so the caller
     /// must hold `lease` at least until the signed transaction has been
@@ -88,13 +80,23 @@ pub trait ExecuteOperation: Send + Sync {
         signed_transaction: SignedTransaction,
     ) -> GatewayResult<Option<StepOutcome>>;
 
-    /// Look up an already-submitted transaction by hash, returning
-    /// [`GatewayError::TransactionNotFound`] when the chain has no record of it.
+    /// Look up an already-submitted transaction by hash.
     async fn query_transaction(
         &self,
         signer_account_id: &ManagedAccountId,
         tx_hash: CryptoHash,
-    ) -> GatewayResult<StepOutcome>;
+    ) -> GatewayResult<TransactionRecord>;
+}
+
+/// What the chain says about a submitted transaction. A failure to *reach* the
+/// chain must be `Err`, never [`TransactionRecord::NoRecord`]: past a
+/// transaction's validity horizon reconciliation treats `NoRecord` as proof it
+/// never landed, and rejects the step.
+pub enum TransactionRecord {
+    /// The chain reported an outcome for the transaction.
+    Executed(StepOutcome),
+    /// Every endpoint queried agreed the chain has no record of the transaction.
+    NoRecord,
 }
 
 #[derive(Clone)]
@@ -122,6 +124,12 @@ impl NearTransactionSigner {
 #[derive(Clone)]
 pub struct NearOperationExecutor {
     network: NetworkConfig,
+    /// One single-endpoint view of `network` per endpoint, so a status query can
+    /// be addressed to each in turn. Retries are stripped: near_api treats
+    /// `UNKNOWN_TRANSACTION` as retryable and would sleep through its whole
+    /// backoff schedule before the answer could be classified, on every orphan of
+    /// every recovery sweep.
+    status_query_networks: Vec<NetworkConfig>,
     finality_policy: FinalityPolicy,
 }
 
@@ -131,9 +139,44 @@ impl NearOperationExecutor {
     }
 
     pub fn with_finality_policy(network: NetworkConfig, finality_policy: FinalityPolicy) -> Self {
+        let status_query_networks = network
+            .rpc_endpoints
+            .iter()
+            .map(|endpoint| NetworkConfig {
+                rpc_endpoints: vec![endpoint.clone().with_retries(1)],
+                ..network.clone()
+            })
+            .collect();
         Self {
             network,
+            status_query_networks,
             finality_policy,
+        }
+    }
+
+    async fn query_transaction_from(
+        &self,
+        network: &NetworkConfig,
+        signer_account_id: &ManagedAccountId,
+        tx_hash: CryptoHash,
+    ) -> GatewayResult<TransactionRecord> {
+        match RequestBuilder::new(
+            TransactionStatusRpc,
+            TransactionStatusRef {
+                sender_account_id: signer_account_id.0.clone(),
+                tx_hash: tx_hash.0,
+                wait_until: self.finality_policy.transaction_status(),
+            },
+            TransactionStatusHandler,
+        )
+        .fetch_from(network)
+        .await
+        {
+            Ok(result) => Ok(TransactionRecord::Executed(StepOutcome::from_execution(
+                result,
+            ))),
+            Err(error) if is_unknown_transaction(&error) => Ok(TransactionRecord::NoRecord),
+            Err(error) => Err(GatewayError::NearTransaction(error.to_string())),
         }
     }
 }
@@ -164,17 +207,6 @@ impl SignTransaction for NearTransactionSigner {
         signer_account_id: &ManagedAccountId,
     ) -> GatewayResult<SigningKeyLease> {
         Ok(self.signer_for(signer_account_id)?.lease_next().await)
-    }
-
-    async fn lease_signing_key(
-        &self,
-        signer_account_id: &ManagedAccountId,
-        public_key: &PublicKey,
-    ) -> Option<SigningKeyLease> {
-        self.signer_for(signer_account_id)
-            .ok()?
-            .lease(public_key)
-            .await
     }
 
     async fn sign_transaction(
@@ -240,29 +272,29 @@ impl ExecuteOperation for NearOperationExecutor {
         &self,
         signer_account_id: &ManagedAccountId,
         tx_hash: CryptoHash,
-    ) -> GatewayResult<StepOutcome> {
-        RequestBuilder::new(
-            TransactionStatusRpc,
-            TransactionStatusRef {
-                sender_account_id: signer_account_id.0.clone(),
-                tx_hash: tx_hash.0,
-                wait_until: self.finality_policy.transaction_status(),
-            },
-            TransactionStatusHandler,
-        )
-        .fetch_from(&self.network)
-        .await
-        // Classify "the chain has no record of this transaction" at the boundary
-        // (on the raw error) into a typed variant, so reconciliation can tell a
-        // never-landed transaction from a transient query failure.
-        .map_err(|error| {
-            if is_unknown_transaction(&error) {
-                GatewayError::TransactionNotFound
-            } else {
-                GatewayError::NearTransaction(error.to_string())
+    ) -> GatewayResult<TransactionRecord> {
+        // near_api walks the endpoints itself, but collapses the walk into a
+        // single last error — so one endpoint's "no record" can be reported while
+        // an earlier one never answered at all. Walking them here keeps the two
+        // apart: an endpoint that failed to respond outranks another's `NoRecord`.
+        if self.status_query_networks.is_empty() {
+            return Err(GatewayError::NearQuery(
+                "no RPC endpoint available for transaction status".to_owned(),
+            ));
+        }
+
+        let mut unanswered = None;
+        for network in &self.status_query_networks {
+            match self
+                .query_transaction_from(network, signer_account_id, tx_hash)
+                .await
+            {
+                Ok(executed @ TransactionRecord::Executed(_)) => return Ok(executed),
+                Ok(TransactionRecord::NoRecord) => {}
+                Err(error) => unanswered = Some(error),
             }
-        })
-        .map(StepOutcome::from_execution)
+        }
+        unanswered.map_or(Ok(TransactionRecord::NoRecord), Err)
     }
 }
 
@@ -275,4 +307,98 @@ fn null_signer() -> Arc<near_api::Signer> {
         [0; 32],
     )))
     .unwrap()
+}
+
+#[cfg(test)]
+mod tests {
+    use near_api::{NetworkConfig, RPCEndpoint};
+    use templar_gateway_types::{CryptoHash, ManagedAccountId};
+    use wiremock::{matchers::method, Mock, MockServer, ResponseTemplate};
+
+    use super::{ExecuteOperation, NearOperationExecutor, TransactionRecord};
+    use crate::GatewayError;
+
+    const UNKNOWN_TRANSACTION: &str = r#"{"jsonrpc":"2.0","id":"0","error":{"name":"HANDLER_ERROR","cause":{"name":"UNKNOWN_TRANSACTION"}}}"#;
+    const INTERNAL_ERROR: &str = r#"{"jsonrpc":"2.0","id":"0","error":{"name":"INTERNAL_ERROR","info":{"error_message":"unavailable"}}}"#;
+
+    async fn responding_with(body: &str) -> MockServer {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(body.to_owned()))
+            .mount(&server)
+            .await;
+        server
+    }
+
+    /// Endpoints are walked in order, so the reply comes from the last one
+    /// consulted rather than the first.
+    fn executor_over(servers: &[&MockServer]) -> NearOperationExecutor {
+        let mut network = NetworkConfig::from_rpc_url("test", servers[0].uri().parse().unwrap());
+        network.rpc_endpoints = servers
+            .iter()
+            .map(|server| RPCEndpoint::new(server.uri().parse().unwrap()))
+            .collect();
+        NearOperationExecutor::new(network)
+    }
+
+    async fn query(executor: &NearOperationExecutor) -> crate::GatewayResult<TransactionRecord> {
+        executor
+            .query_transaction(
+                &ManagedAccountId("signer.near".parse().unwrap()),
+                CryptoHash(near_api::types::CryptoHash::default()),
+            )
+            .await
+    }
+
+    #[tokio::test]
+    async fn every_endpoint_agreeing_on_no_record_is_an_answer() {
+        let primary = responding_with(UNKNOWN_TRANSACTION).await;
+        let archival = responding_with(UNKNOWN_TRANSACTION).await;
+
+        let record = query(&executor_over(&[&primary, &archival])).await.unwrap();
+
+        assert!(matches!(record, TransactionRecord::NoRecord));
+    }
+
+    /// The safety property the horizon rule rests on: an endpoint that failed to
+    /// answer leaves the question open, so its silence must not be reported as
+    /// the chain having no record — that would reject a transaction which may
+    /// well have executed.
+    #[tokio::test]
+    async fn an_unreachable_endpoint_is_an_error_not_an_answer() {
+        let unreachable = responding_with(INTERNAL_ERROR).await;
+        let archival = responding_with(UNKNOWN_TRANSACTION).await;
+
+        let result = query(&executor_over(&[&unreachable, &archival])).await;
+
+        assert!(
+            matches!(result, Err(GatewayError::NearTransaction(_))),
+            "an unanswered endpoint must not resolve to NoRecord"
+        );
+    }
+
+    /// With nothing to ask, there is no answer — reporting `NoRecord` here would
+    /// let reconciliation reject a transaction nobody looked for.
+    #[tokio::test]
+    async fn a_configuration_with_no_endpoints_is_an_error_not_an_answer() {
+        let mut network =
+            NetworkConfig::from_rpc_url("test", "http://127.0.0.1:1".parse().unwrap());
+        network.rpc_endpoints.clear();
+
+        let result = query(&NearOperationExecutor::new(network)).await;
+
+        assert!(
+            matches!(result, Err(GatewayError::NearQuery(_))),
+            "an unasked question must not resolve to NoRecord"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_lone_endpoint_reporting_no_record_is_an_answer() {
+        let primary = responding_with(UNKNOWN_TRANSACTION).await;
+
+        let record = query(&executor_over(&[&primary])).await.unwrap();
+
+        assert!(matches!(record, TransactionRecord::NoRecord));
+    }
 }

--- a/gateway/core/src/executor.rs
+++ b/gateway/core/src/executor.rs
@@ -129,7 +129,8 @@ impl NearTransactionSigner {
 pub struct NearOperationExecutor {
     network: NetworkConfig,
     /// Retention-complete view of the chain, when one is configured. Absent, a
-    /// missing transaction can never be confirmed missing.
+    /// missing transaction can never be confirmed missing — see
+    /// [`TransactionRecord::Unconfirmed`].
     archival_status_network: Option<NetworkConfig>,
     /// One single-endpoint, single-attempt view of `network` per endpoint, so a
     /// status query can be addressed to each in turn.
@@ -138,11 +139,20 @@ pub struct NearOperationExecutor {
 }
 
 impl NearOperationExecutor {
-    pub fn new(network: NetworkConfig) -> Self {
-        Self::with_finality_policy(network, FinalityPolicy::default())
+    pub fn new(network: NetworkConfig, archival_network: Option<NetworkConfig>) -> Self {
+        Self::with_finality_policy(network, archival_network, FinalityPolicy::default())
     }
 
-    pub fn with_finality_policy(network: NetworkConfig, finality_policy: FinalityPolicy) -> Self {
+    /// `archival_network` is required rather than opt-in: it is what lets
+    /// reconciliation terminally reject a transaction the chain has no record of,
+    /// so a consumer that never considers it silently loses that — and its
+    /// operations stay in flight forever. `None` is a deliberate choice to do
+    /// without, not an oversight the type permits.
+    pub fn with_finality_policy(
+        network: NetworkConfig,
+        archival_network: Option<NetworkConfig>,
+        finality_policy: FinalityPolicy,
+    ) -> Self {
         let status_query_networks = network
             .rpc_endpoints
             .iter()
@@ -154,18 +164,11 @@ impl NearOperationExecutor {
         Self {
             network,
             status_query_networks,
-            archival_status_network: None,
+            archival_status_network: archival_network
+                .as_ref()
+                .map(|network| Self::status_query(network)),
             finality_policy,
         }
-    }
-
-    /// Supply the archival endpoint reconciliation consults when the primary has
-    /// no record of a transaction. Without it, a missing transaction resolves to
-    /// [`TransactionRecord::Unconfirmed`] and its step is never rejected.
-    #[must_use]
-    pub fn with_archival_network(mut self, archival_network: Option<NetworkConfig>) -> Self {
-        self.archival_status_network = archival_network.map(|network| Self::status_query(&network));
-        self
     }
 
     /// A single-attempt view of `network`. near_api treats `UNKNOWN_TRANSACTION`
@@ -390,8 +393,10 @@ mod tests {
                 .collect();
             network
         };
-        NearOperationExecutor::new(network_over(servers.to_vec()))
-            .with_archival_network(archival.map(|server| network_over(vec![server])))
+        NearOperationExecutor::new(
+            network_over(servers.to_vec()),
+            archival.map(|server| network_over(vec![server])),
+        )
     }
 
     async fn query(executor: &NearOperationExecutor) -> crate::GatewayResult<TransactionRecord> {
@@ -460,7 +465,7 @@ mod tests {
             NetworkConfig::from_rpc_url("test", "http://127.0.0.1:1".parse().unwrap());
         network.rpc_endpoints.clear();
 
-        let result = query(&NearOperationExecutor::new(network)).await;
+        let result = query(&NearOperationExecutor::new(network, None)).await;
 
         assert!(
             matches!(result, Err(GatewayError::NearQuery(_))),

--- a/gateway/core/src/executor.rs
+++ b/gateway/core/src/executor.rs
@@ -88,15 +88,19 @@ pub trait ExecuteOperation: Send + Sync {
     ) -> GatewayResult<TransactionRecord>;
 }
 
-/// What the chain says about a submitted transaction. A failure to *reach* the
-/// chain must be `Err`, never [`TransactionRecord::NoRecord`]: past a
-/// transaction's validity horizon reconciliation treats `NoRecord` as proof it
-/// never landed, and rejects the step.
+/// What the chain says about a submitted transaction.
 pub enum TransactionRecord {
     /// The chain reported an outcome for the transaction.
     Executed(StepOutcome),
-    /// Every endpoint queried agreed the chain has no record of the transaction.
+    /// An archival node — which retains history rather than garbage collecting
+    /// it — has no record of the transaction. Only this is evidence that it
+    /// never executed, and past its validity horizon reconciliation rejects the
+    /// step on it.
     NoRecord,
+    /// No node that retains history answered, so absence of a record proves
+    /// nothing: a primary node discards outcomes it no longer needs, and reports
+    /// a transaction that did execute exactly as it reports one that never did.
+    Unconfirmed,
 }
 
 #[derive(Clone)]
@@ -124,11 +128,11 @@ impl NearTransactionSigner {
 #[derive(Clone)]
 pub struct NearOperationExecutor {
     network: NetworkConfig,
-    /// One single-endpoint view of `network` per endpoint, so a status query can
-    /// be addressed to each in turn. Retries are stripped: near_api treats
-    /// `UNKNOWN_TRANSACTION` as retryable and would sleep through its whole
-    /// backoff schedule before the answer could be classified, on every orphan of
-    /// every recovery sweep.
+    /// Retention-complete view of the chain, when one is configured. Absent, a
+    /// missing transaction can never be confirmed missing.
+    archival_status_network: Option<NetworkConfig>,
+    /// One single-endpoint, single-attempt view of `network` per endpoint, so a
+    /// status query can be addressed to each in turn.
     status_query_networks: Vec<NetworkConfig>,
     finality_policy: FinalityPolicy,
 }
@@ -150,16 +154,43 @@ impl NearOperationExecutor {
         Self {
             network,
             status_query_networks,
+            archival_status_network: None,
             finality_policy,
         }
     }
 
-    async fn query_transaction_from(
+    /// Supply the archival endpoint reconciliation consults when the primary has
+    /// no record of a transaction. Without it, a missing transaction resolves to
+    /// [`TransactionRecord::Unconfirmed`] and its step is never rejected.
+    #[must_use]
+    pub fn with_archival_network(mut self, archival_network: Option<NetworkConfig>) -> Self {
+        self.archival_status_network = archival_network.map(|network| Self::status_query(&network));
+        self
+    }
+
+    /// A single-attempt view of `network`. near_api treats `UNKNOWN_TRANSACTION`
+    /// as retryable and would sleep through its whole backoff schedule before the
+    /// answer could be classified, on every orphan of every recovery sweep.
+    fn status_query(network: &NetworkConfig) -> NetworkConfig {
+        NetworkConfig {
+            rpc_endpoints: network
+                .rpc_endpoints
+                .iter()
+                .map(|endpoint| endpoint.clone().with_retries(1))
+                .collect(),
+            ..network.clone()
+        }
+    }
+
+    /// `Ok(None)` when this node has no record of the transaction. Whether that
+    /// is evidence of anything depends on whether the node retains history, which
+    /// is the caller's to judge.
+    async fn transaction_outcome_from(
         &self,
         network: &NetworkConfig,
         signer_account_id: &ManagedAccountId,
         tx_hash: CryptoHash,
-    ) -> GatewayResult<TransactionRecord> {
+    ) -> GatewayResult<Option<StepOutcome>> {
         match RequestBuilder::new(
             TransactionStatusRpc,
             TransactionStatusRef {
@@ -172,10 +203,8 @@ impl NearOperationExecutor {
         .fetch_from(network)
         .await
         {
-            Ok(result) => Ok(TransactionRecord::Executed(StepOutcome::from_execution(
-                result,
-            ))),
-            Err(error) if is_unknown_transaction(&error) => Ok(TransactionRecord::NoRecord),
+            Ok(result) => Ok(Some(StepOutcome::from_execution(result))),
+            Err(error) if is_unknown_transaction(&error) => Ok(None),
             Err(error) => Err(GatewayError::NearTransaction(error.to_string())),
         }
     }
@@ -273,10 +302,9 @@ impl ExecuteOperation for NearOperationExecutor {
         signer_account_id: &ManagedAccountId,
         tx_hash: CryptoHash,
     ) -> GatewayResult<TransactionRecord> {
-        // near_api walks the endpoints itself, but collapses the walk into a
-        // single last error — so one endpoint's "no record" can be reported while
-        // an earlier one never answered at all. Walking them here keeps the two
-        // apart: an endpoint that failed to respond outranks another's `NoRecord`.
+        // near_api walks the endpoints itself but collapses the walk into a single
+        // last error, losing which node said what. Walking them here keeps the
+        // primaries' answers separate from the archival one that can settle them.
         if self.status_query_networks.is_empty() {
             return Err(GatewayError::NearQuery(
                 "no RPC endpoint available for transaction status".to_owned(),
@@ -286,15 +314,31 @@ impl ExecuteOperation for NearOperationExecutor {
         let mut unanswered = None;
         for network in &self.status_query_networks {
             match self
-                .query_transaction_from(network, signer_account_id, tx_hash)
+                .transaction_outcome_from(network, signer_account_id, tx_hash)
                 .await
             {
-                Ok(executed @ TransactionRecord::Executed(_)) => return Ok(executed),
-                Ok(TransactionRecord::NoRecord) => {}
+                Ok(Some(outcome)) => return Ok(TransactionRecord::Executed(outcome)),
+                Ok(None) => {}
                 Err(error) => unanswered = Some(error),
             }
         }
-        unanswered.map_or(Ok(TransactionRecord::NoRecord), Err)
+
+        let Some(archival) = &self.archival_status_network else {
+            return unanswered.map_or(Ok(TransactionRecord::Unconfirmed), Err);
+        };
+
+        // The only construction of `NoRecord`, reachable only from the archival
+        // branch — which is what keeps a primary node's garbage collection from
+        // being mistaken for proof that a transaction never executed.
+        Ok(
+            match self
+                .transaction_outcome_from(archival, signer_account_id, tx_hash)
+                .await?
+            {
+                Some(outcome) => TransactionRecord::Executed(outcome),
+                None => TransactionRecord::NoRecord,
+            },
+        )
     }
 }
 
@@ -330,15 +374,24 @@ mod tests {
         server
     }
 
-    /// Endpoints are walked in order, so the reply comes from the last one
-    /// consulted rather than the first.
-    fn executor_over(servers: &[&MockServer]) -> NearOperationExecutor {
-        let mut network = NetworkConfig::from_rpc_url("test", servers[0].uri().parse().unwrap());
-        network.rpc_endpoints = servers
-            .iter()
-            .map(|server| RPCEndpoint::new(server.uri().parse().unwrap()))
-            .collect();
-        NearOperationExecutor::new(network)
+    async fn requests_to(server: &MockServer) -> usize {
+        server.received_requests().await.unwrap_or_default().len()
+    }
+
+    fn executor_over(
+        servers: &[&MockServer],
+        archival: Option<&MockServer>,
+    ) -> NearOperationExecutor {
+        let network_over = |urls: Vec<&MockServer>| {
+            let mut network = NetworkConfig::from_rpc_url("test", urls[0].uri().parse().unwrap());
+            network.rpc_endpoints = urls
+                .iter()
+                .map(|server| RPCEndpoint::new(server.uri().parse().unwrap()))
+                .collect();
+            network
+        };
+        NearOperationExecutor::new(network_over(servers.to_vec()))
+            .with_archival_network(archival.map(|server| network_over(vec![server])))
     }
 
     async fn query(executor: &NearOperationExecutor) -> crate::GatewayResult<TransactionRecord> {
@@ -350,35 +403,57 @@ mod tests {
             .await
     }
 
+    /// Absence of a record is only evidence from a node that retains history, so
+    /// a primary saying so on its own must not resolve to `NoRecord` — it would
+    /// let the horizon rule reject a transaction whose outcome was merely
+    /// garbage collected.
     #[tokio::test]
-    async fn every_endpoint_agreeing_on_no_record_is_an_answer() {
+    async fn a_primary_alone_cannot_confirm_a_missing_transaction() {
+        let primary = responding_with(UNKNOWN_TRANSACTION).await;
+
+        let record = query(&executor_over(&[&primary], None)).await.unwrap();
+
+        assert!(matches!(record, TransactionRecord::Unconfirmed));
+    }
+
+    #[tokio::test]
+    async fn an_archival_endpoint_confirms_a_missing_transaction() {
         let primary = responding_with(UNKNOWN_TRANSACTION).await;
         let archival = responding_with(UNKNOWN_TRANSACTION).await;
 
-        let record = query(&executor_over(&[&primary, &archival])).await.unwrap();
+        let record = query(&executor_over(&[&primary], Some(&archival)))
+            .await
+            .unwrap();
 
         assert!(matches!(record, TransactionRecord::NoRecord));
+        assert_eq!(requests_to(&primary).await, 1, "one request per endpoint");
+        assert_eq!(requests_to(&archival).await, 1, "one request per endpoint");
     }
 
-    /// The safety property the horizon rule rests on: an endpoint that failed to
-    /// answer leaves the question open, so its silence must not be reported as
-    /// the chain having no record — that would reject a transaction which may
-    /// well have executed.
+    /// An archival endpoint that cannot be reached has confirmed nothing.
     #[tokio::test]
-    async fn an_unreachable_endpoint_is_an_error_not_an_answer() {
-        let unreachable = responding_with(INTERNAL_ERROR).await;
-        let archival = responding_with(UNKNOWN_TRANSACTION).await;
+    async fn an_unreachable_archival_endpoint_is_an_error_not_an_answer() {
+        let primary = responding_with(UNKNOWN_TRANSACTION).await;
+        let archival = responding_with(INTERNAL_ERROR).await;
 
-        let result = query(&executor_over(&[&unreachable, &archival])).await;
+        let result = query(&executor_over(&[&primary], Some(&archival))).await;
 
         assert!(
             matches!(result, Err(GatewayError::NearTransaction(_))),
-            "an unanswered endpoint must not resolve to NoRecord"
+            "an unreachable archival endpoint must not resolve to NoRecord"
         );
     }
 
-    /// With nothing to ask, there is no answer — reporting `NoRecord` here would
-    /// let reconciliation reject a transaction nobody looked for.
+    #[tokio::test]
+    async fn an_unreachable_primary_without_archival_is_an_error() {
+        let primary = responding_with(INTERNAL_ERROR).await;
+
+        let result = query(&executor_over(&[&primary], None)).await;
+
+        assert!(matches!(result, Err(GatewayError::NearTransaction(_))));
+    }
+
+    /// With nothing to ask, there is no answer.
     #[tokio::test]
     async fn a_configuration_with_no_endpoints_is_an_error_not_an_answer() {
         let mut network =
@@ -391,14 +466,5 @@ mod tests {
             matches!(result, Err(GatewayError::NearQuery(_))),
             "an unasked question must not resolve to NoRecord"
         );
-    }
-
-    #[tokio::test]
-    async fn a_lone_endpoint_reporting_no_record_is_an_answer() {
-        let primary = responding_with(UNKNOWN_TRANSACTION).await;
-
-        let record = query(&executor_over(&[&primary])).await.unwrap();
-
-        assert!(matches!(record, TransactionRecord::NoRecord));
     }
 }

--- a/gateway/core/src/lib.rs
+++ b/gateway/core/src/lib.rs
@@ -26,7 +26,7 @@ pub use contract_kind::query_contract_kind;
 pub use error::{GatewayError, GatewayResult};
 pub use executor::{
     ExecuteOperation, NearOperationExecutor, NearTransactionSigner, SharedExecuteOperation,
-    SharedSignTransaction, SignTransaction, StepOutcome,
+    SharedSignTransaction, SignTransaction, StepOutcome, TransactionRecord,
 };
 pub use finality::FinalityPolicy;
 pub use near_client_provider::HasNearClient;

--- a/gateway/core/src/operation.rs
+++ b/gateway/core/src/operation.rs
@@ -3,7 +3,7 @@ use std::{collections::VecDeque, sync::Arc};
 use chrono::{DateTime, Utc};
 use near_api::types::{
     transaction::{actions::Action, SignedTransaction},
-    AccountId, PublicKey,
+    AccountId,
 };
 use serde::{Deserialize, Serialize};
 use templar_gateway_types::{
@@ -183,11 +183,16 @@ pub struct StoredOperation {
 
 pub type SharedOperationStore = Arc<dyn OperationStore>;
 
+/// The right to install a freshly signed step. Holds no transaction: ownership
+/// passes to the caller to sign, and the operation is not touched until
+/// [`PendingPreparation::finish`].
 #[must_use]
 pub struct PendingPreparation<'a> {
     operation: &'a mut StoredOperation,
     store: SharedOperationStore,
-    transaction: PlannedTransaction,
+    /// Whether the step is still queued in `remaining_steps` and so must be
+    /// dequeued on completion, rather than already occupying the cursor.
+    queued: bool,
 }
 
 #[must_use]
@@ -211,19 +216,6 @@ pub enum CurrentStepRef<'a> {
     Prepared(Box<PreparedCurrentStep<'a>>),
     Submitted(Box<SubmittedCurrentStep<'a>>),
     Failed,
-}
-
-/// Which access key the next step needs.
-pub(crate) enum SigningTarget<'a> {
-    /// Signed in an earlier pass, so its nonce is bound to this key.
-    Bound {
-        signer_account_id: &'a ManagedAccountId,
-        public_key: PublicKey,
-    },
-    /// Not signed yet, so any of the account's keys will do.
-    Next {
-        signer_account_id: &'a ManagedAccountId,
-    },
 }
 
 impl StoredOperation {
@@ -324,50 +316,65 @@ impl StoredOperation {
         }
     }
 
+    /// Record `transaction` as having failed without a recorded on-chain
+    /// execution. Unlike a revert, this is unconditionally terminal:
+    /// [`CompletedStep`] has no rejected variant, so a rejection cannot be
+    /// tolerated by [`PlannedTransaction::continue_on_failure`]. Carrying no
+    /// [`ExecutionOutcome`] is what releases the step's charge.
+    pub fn record_rejection(&mut self, transaction: PlannedTransaction, tx_hash: CryptoHash) {
+        self.current_step = Some(CurrentStep::Rejected {
+            transaction,
+            tx_hash,
+        });
+    }
+
+    /// Take the next step's transaction to be signed, replacing the signature of
+    /// one already `Prepared` rather than reusing it. Nothing moves until
+    /// [`PendingPreparation::finish`].
+    ///
+    /// A stored signature is bound to a block hash NEAR only accepts for ~24h,
+    /// after which resubmitting it yields `Expired` forever. This is the sole
+    /// route to a submittable [`PreparedCurrentStep`], which is what makes a
+    /// stale signature unreachable rather than merely discouraged. Dropping it
+    /// cannot double-submit: [`PreparedCurrentStep::submit`] records `Submitted`
+    /// *before* broadcasting, so a persisted `Prepared` step never reached the
+    /// network.
     #[must_use]
     pub fn begin_next_preparation(
         &mut self,
         store: SharedOperationStore,
-    ) -> Option<PendingPreparation<'_>> {
-        if self.current_step.is_some() {
-            return None;
-        }
+    ) -> Option<(PendingPreparation<'_>, PlannedTransaction)> {
+        let transaction = self.next_transaction()?.clone();
+        let queued = self.current_step.is_none();
 
-        let transaction = self.remaining_steps.pop_front()?;
-
-        Some(PendingPreparation {
-            operation: self,
-            store,
+        Some((
+            PendingPreparation {
+                operation: self,
+                store,
+                queued,
+            },
             transaction,
-        })
+        ))
     }
 
-    /// The access key the next step must sign or resubmit with, or `None` when
-    /// no step is ready for either. Lives beside the step cursor so it cannot
-    /// disagree with [`begin_next_preparation`](Self::begin_next_preparation)
-    /// about which step is next.
-    pub(crate) fn signing_target(&self) -> Option<SigningTarget<'_>> {
+    /// The next step to sign, wherever it currently sits. Single source of truth
+    /// for [`begin_next_preparation`](Self::begin_next_preparation) and
+    /// [`signing_target`](Self::signing_target), so they cannot disagree.
+    fn next_transaction(&self) -> Option<&PlannedTransaction> {
         match &self.current_step {
-            Some(CurrentStep::Prepared {
-                transaction,
-                signed_transaction,
-                ..
-            }) => Some(SigningTarget::Bound {
-                signer_account_id: &transaction.signer_account_id,
-                public_key: signed_transaction.transaction.public_key(),
-            }),
-            Some(
-                CurrentStep::Submitted { .. }
-                | CurrentStep::Reverted { .. }
-                | CurrentStep::Rejected { .. },
-            ) => None,
-            None => self
-                .remaining_steps
-                .front()
-                .map(|transaction| SigningTarget::Next {
-                    signer_account_id: &transaction.signer_account_id,
-                }),
+            Some(CurrentStep::Prepared { transaction, .. }) => Some(transaction),
+            Some(_) => None,
+            None => self.remaining_steps.front(),
         }
+    }
+
+    /// The account the next step must sign under, or `None` when no step is
+    /// ready to sign. Any of that account's keys will do: every step named here
+    /// is signed afresh, so none is bound to the key that signed an earlier
+    /// attempt.
+    pub(crate) fn signing_target(&self) -> Option<&ManagedAccountId> {
+        self.next_transaction()
+            .map(|transaction| &transaction.signer_account_id)
     }
 
     #[must_use]
@@ -462,11 +469,13 @@ impl StoredOperation {
 }
 
 impl PendingPreparation<'_> {
-    pub fn transaction(&self) -> &PlannedTransaction {
-        &self.transaction
-    }
-
+    /// Install the signature and advance the cursor onto the step, together. A
+    /// preparation abandoned before this — a signing failure, an early return —
+    /// leaves the operation exactly as it was found.
     pub async fn finish(self, prepared: PreparedTransactionResult) -> GatewayResult<()> {
+        if self.queued {
+            self.operation.remaining_steps.pop_front();
+        }
         self.operation.current_step = Some(CurrentStep::Prepared {
             transaction: prepared.transaction,
             signed_transaction: Box::new(prepared.signed_transaction),

--- a/gateway/core/src/operation_driver.rs
+++ b/gateway/core/src/operation_driver.rs
@@ -3,6 +3,7 @@ use std::{
     sync::Arc,
 };
 
+use chrono::{TimeDelta, Utc};
 use serde::Serialize;
 use sha2::{Digest, Sha256};
 use templar_gateway_types::{
@@ -11,13 +12,17 @@ use templar_gateway_types::{
     IdempotencyKey, MethodSpec, OperationId,
 };
 
-use crate::operation::SigningTarget;
 use crate::{
     CreateOperationResult, CurrentStep, CurrentStepRef, GatewayError, GatewayResult,
     HasIdempotencyKey, HasSignerAccountId, OperationPlan, PlanWrite, SharedExecuteOperation,
     SharedOperationStore, SharedSignTransaction, SigningKeyLease, StoredOperation,
+    TransactionRecord,
 };
 use tokio::sync::{Mutex, OwnedMutexGuard};
+
+/// Twice a NEAR transaction's ~24h block-hash validity, leaving margin for clock
+/// skew between this process and the chain.
+const TRANSACTION_VALIDITY_HORIZON: TimeDelta = TimeDelta::hours(48);
 
 #[derive(Default)]
 struct OperationLocks {
@@ -34,26 +39,6 @@ impl OperationLocks {
                 .clone()
         };
         lock.lock_owned().await
-    }
-}
-
-/// A step's claim on the access key it signs and broadcasts with.
-enum StepLane {
-    /// No step is ready to sign or submit.
-    Idle,
-    /// Exclusive use of the key, held until the step reaches the network.
-    Held(SigningKeyLease),
-    /// The step is bound to a key this process does not hold. Nothing here can
-    /// allocate a nonce on that key, so its stored signature replays unguarded.
-    Unheld,
-}
-
-impl StepLane {
-    fn held(&self) -> Option<&SigningKeyLease> {
-        match self {
-            Self::Held(lease) => Some(lease),
-            Self::Idle | Self::Unheld => None,
-        }
     }
 }
 
@@ -400,12 +385,11 @@ impl OperationDriver {
             .await?
             .unwrap_or(operation);
 
-        let lane = self.lease_step_lane(&operation).await?;
-        if matches!(lane, StepLane::Idle) {
+        let Some(lease) = self.lease_step_lane(&operation).await? else {
             return Ok(operation);
-        }
+        };
 
-        self.prepare_next_step(&mut operation, &lane).await?;
+        self.prepare_next_step(&mut operation, &lease).await?;
 
         if let Some(CurrentStepRef::Prepared(prepared_step)) = operation.current(self.store.clone())
         {
@@ -429,53 +413,34 @@ impl OperationDriver {
     /// which is wider than the invariant needs and caps a key at one write per
     /// finality round-trip. Narrowing that to the broadcast itself needs a
     /// submit path that returns before execution (see `FinalityPolicy`).
-    async fn lease_step_lane(&self, operation: &StoredOperation) -> GatewayResult<StepLane> {
-        Ok(match operation.signing_target() {
-            Some(SigningTarget::Bound {
-                signer_account_id,
-                public_key,
-            }) => {
-                if let Some(lease) = self
-                    .transaction_signer
-                    .lease_signing_key(signer_account_id, &public_key)
-                    .await
-                {
-                    StepLane::Held(lease)
-                } else {
-                    tracing::warn!(
-                        signer_account_id = %signer_account_id.0,
-                        %public_key,
-                        "replaying a prepared step signed with an access key this process no longer holds"
-                    );
-                    StepLane::Unheld
-                }
-            }
-            Some(SigningTarget::Next { signer_account_id }) => StepLane::Held(
-                self.transaction_signer
-                    .lease_next_signing_key(signer_account_id)
-                    .await?,
-            ),
-            None => StepLane::Idle,
-        })
+    async fn lease_step_lane(
+        &self,
+        operation: &StoredOperation,
+    ) -> GatewayResult<Option<SigningKeyLease>> {
+        let Some(signer_account_id) = operation.signing_target() else {
+            return Ok(None);
+        };
+        self.transaction_signer
+            .lease_next_signing_key(signer_account_id)
+            .await
+            .map(Some)
     }
 
-    /// Sign the next step, if there is one and the lane covers it. An `Unheld`
-    /// lane always accompanies an already-signed step, so nothing is skipped by
-    /// declining to sign without one.
+    /// Sign the next step under `lease`, if there is one. A step already signed
+    /// by an earlier run is re-signed rather than replayed — see
+    /// [`StoredOperation::begin_next_preparation`].
     async fn prepare_next_step(
         &self,
         operation: &mut StoredOperation,
-        lane: &StepLane,
+        lease: &SigningKeyLease,
     ) -> GatewayResult<()> {
-        let Some(lease) = lane.held() else {
-            return Ok(());
-        };
-        let Some(pending) = operation.begin_next_preparation(self.store.clone()) else {
+        let Some((pending, transaction)) = operation.begin_next_preparation(self.store.clone())
+        else {
             return Ok(());
         };
         let prepared = self
             .transaction_signer
-            .sign_transaction(lease, pending.transaction().clone())
+            .sign_transaction(lease, transaction)
             .await?;
         pending.finish(prepared).await
     }
@@ -488,12 +453,11 @@ impl OperationDriver {
             return Ok(operation);
         }
 
-        let lane = self.lease_step_lane(&operation).await?;
-        if matches!(lane, StepLane::Idle) {
+        let Some(lease) = self.lease_step_lane(&operation).await? else {
             return Ok(operation);
-        }
+        };
 
-        self.prepare_next_step(&mut operation, &lane).await?;
+        self.prepare_next_step(&mut operation, &lease).await?;
 
         let operation_id = operation.operation_id().clone();
         match operation.current(self.store.clone()) {
@@ -590,62 +554,82 @@ impl OperationDriver {
         ))
     }
 
-    /// Query a submitted step's on-chain fate and record it. The ambiguous case —
-    /// a transaction the chain has no record of — is left submitted because NEAR
-    /// `UNKNOWN_TRANSACTION` is not proof that the transaction never landed.
+    /// Query a submitted step's on-chain fate and record it. A transaction the
+    /// chain has no record of is ambiguous only while it could still land: NEAR
+    /// `UNKNOWN_TRANSACTION` is not proof that it never did, but past
+    /// [`TRANSACTION_VALIDITY_HORIZON`] the transaction can no longer be applied,
+    /// so the same answer becomes proof and the step is rejected.
     async fn reconcile_submitted_step(&self, operation: &mut StoredOperation) {
-        if let Some(CurrentStep::Submitted {
+        let Some(CurrentStep::Submitted {
             transaction,
             tx_hash,
             submitted_at,
-        }) = operation.current_step.take()
+        }) = operation.current_step.clone()
+        else {
+            return;
+        };
+
+        // An arm that does not resolve the step leaves `current_step` untouched,
+        // so staying submitted is what happens by default rather than something a
+        // future arm has to remember to do.
+        match self
+            .operation_executor
+            .query_transaction(&transaction.signer_account_id, tx_hash)
+            .await
         {
-            match self
-                .operation_executor
-                .query_transaction(&transaction.signer_account_id, tx_hash)
-                .await
-            {
-                Ok(step) => {
-                    if step.is_success {
-                        operation.record_success(transaction, tx_hash, step.outcome);
+            Ok(TransactionRecord::Executed(step)) => {
+                if step.is_success {
+                    operation.record_success(transaction, tx_hash, step.outcome);
+                } else {
+                    // Tolerance is decided by the step's own flag, so a
+                    // continue_on_failure step reverting mid-reconcile advances
+                    // rather than blocking — same rule as live execution. A
+                    // tolerated revert is routine (log quietly); only a terminal,
+                    // blocking revert warrants a warning.
+                    if transaction.continue_on_failure {
+                        tracing::debug!(
+                            operation_id = %operation.id.0,
+                            %tx_hash,
+                            "tolerated step reverted during reconciliation; operation advances"
+                        );
                     } else {
-                        // Tolerance is decided by the step's own flag, so a
-                        // continue_on_failure step reverting mid-reconcile advances
-                        // rather than blocking — same rule as live execution. A
-                        // tolerated revert is routine (log quietly); only a terminal,
-                        // blocking revert warrants a warning.
-                        if transaction.continue_on_failure {
-                            tracing::debug!(
-                                operation_id = %operation.id.0,
-                                %tx_hash,
-                                "tolerated step reverted during reconciliation; operation advances"
-                            );
-                        } else {
-                            tracing::warn!(
-                                operation_id = %operation.id.0,
-                                %tx_hash,
-                                "current step transaction reverted"
-                            );
-                        }
-                        operation.record_revert(transaction, tx_hash, step.outcome);
+                        tracing::warn!(
+                            operation_id = %operation.id.0,
+                            %tx_hash,
+                            "current step transaction reverted"
+                        );
                     }
+                    operation.record_revert(transaction, tx_hash, step.outcome);
                 }
-                Err(error) => {
-                    // A transient failure or unknown transaction may still have
-                    // executed, so do NOT reject. Leave it submitted to reconcile
-                    // on a later sweep.
+            }
+            Ok(TransactionRecord::NoRecord) => {
+                let age = Utc::now().signed_duration_since(submitted_at);
+                if age > TRANSACTION_VALIDITY_HORIZON {
                     tracing::warn!(
                         operation_id = %operation.id.0,
                         %tx_hash,
-                        %error,
-                        "leaving submitted gateway transaction for a later reconciliation"
+                        age_hours = age.num_hours(),
+                        "rejecting a submitted transaction the chain has no record of past its validity horizon"
                     );
-                    operation.current_step = Some(CurrentStep::Submitted {
-                        transaction,
-                        tx_hash,
-                        submitted_at,
-                    });
+                    operation.record_rejection(transaction, tx_hash);
+                } else {
+                    tracing::debug!(
+                        operation_id = %operation.id.0,
+                        %tx_hash,
+                        age_hours = age.num_hours(),
+                        "chain has no record of a submitted transaction that could still land"
+                    );
                 }
+            }
+            Err(error) => {
+                // The chain was not reached, so the transaction may yet have
+                // executed. Reconcile again on a later sweep.
+                tracing::warn!(
+                    operation_id = %operation.id.0,
+                    %tx_hash,
+                    %error,
+                    "leaving submitted gateway transaction for a later reconciliation"
+                );
             }
         }
     }

--- a/gateway/core/src/operation_driver.rs
+++ b/gateway/core/src/operation_driver.rs
@@ -20,8 +20,10 @@ use crate::{
 };
 use tokio::sync::{Mutex, OwnedMutexGuard};
 
-/// Twice a NEAR transaction's ~24h block-hash validity, leaving margin for clock
-/// skew between this process and the chain.
+/// Twice a NEAR transaction's ~24h block-hash validity. Expiry is really counted
+/// in blocks from the referenced block, so wall-clock is a proxy: the doubling
+/// absorbs block-time variance but not a multi-day halt, where a transaction
+/// older than this can still be valid (ENG-675).
 const TRANSACTION_VALIDITY_HORIZON: TimeDelta = TimeDelta::hours(48);
 
 #[derive(Default)]
@@ -620,6 +622,14 @@ impl OperationDriver {
                         "chain has no record of a submitted transaction that could still land"
                     );
                 }
+            }
+            Ok(TransactionRecord::Unconfirmed) => {
+                tracing::warn!(
+                    operation_id = %operation.id.0,
+                    %tx_hash,
+                    "no archival endpoint to confirm the chain has no record of this transaction; \
+                     leaving it submitted"
+                );
             }
             Err(error) => {
                 // The chain was not reached, so the transaction may yet have

--- a/gateway/core/src/signer.rs
+++ b/gateway/core/src/signer.rs
@@ -136,9 +136,8 @@ impl PooledSigner {
         lease
     }
 
-    /// Lease one specific key — for resubmitting a transaction already signed
-    /// with it, whose nonce is bound to that key. `None` when the pool does not
-    /// hold the key, and so cannot allocate a nonce on it at all.
+    /// Lease one specific key. `None` when the pool does not hold it, and so
+    /// cannot allocate a nonce on it at all.
     pub async fn lease(&self, public_key: &PublicKey) -> Option<SigningKeyLease> {
         let slot = self.slots().find(|slot| slot.public_key == *public_key)?;
         Some(slot.lease(self.account_id.clone()).await)

--- a/gateway/core/tests/direct_usage.rs
+++ b/gateway/core/tests/direct_usage.rs
@@ -107,7 +107,7 @@ async fn core_finality_policies_keep_immediate_reads_consistent() -> Result<()> 
         assert_eq!(plan.steps[0].actions.len(), 1);
 
         let operation_executor =
-            NearOperationExecutor::with_finality_policy(network.clone(), finality_policy);
+            NearOperationExecutor::with_finality_policy(network.clone(), None, finality_policy);
         let lease = transaction_signer
             .lease_next_signing_key(&signer_account_id)
             .await?;

--- a/gateway/store/tests/driver_recovery.rs
+++ b/gateway/store/tests/driver_recovery.rs
@@ -576,9 +576,9 @@ async fn reconcile_resolves_submitted_step(
     }
 }
 
-/// A submitted transaction the chain has no record of stays submitted while it
-/// could still land, because `UNKNOWN_TRANSACTION` is not proof that it never
-/// did. Past the validity horizon the transaction can no longer be applied, so
+/// A transaction an archival node confirms it has no record of stays submitted
+/// while it could still land, because `UNKNOWN_TRANSACTION` is not proof that it
+/// never did. Past the validity horizon the transaction can no longer be applied, so
 /// the same answer becomes proof and the step is rejected rather than re-queried
 /// forever.
 #[rstest]
@@ -625,6 +625,26 @@ async fn an_abandoned_preparation_leaves_the_plan_intact(#[case] mut op: StoredO
 
     assert_eq!(op.remaining_steps.len(), queued_before);
     assert_eq!(op.current_step.is_some(), current_before);
+}
+
+/// Age alone must not reject. Without an archival node confirming it, a missing
+/// transaction is indistinguishable from one whose outcome the primary garbage
+/// collected — and that one may well have executed.
+#[tokio::test]
+async fn an_unconfirmed_missing_transaction_is_never_rejected() {
+    let store = Arc::new(MemoryStore::new());
+    let key = seed_keyed(&store, "unconfirmed", step_op(expired_submitted_step())).await;
+    let executor = FakeExecutor::new(vec![], vec![Ok(TransactionRecord::Unconfirmed)]);
+
+    let record = driver(store.clone(), executor)
+        .reconcile_operation(&key)
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(record.status, OperationStatus::InProgress);
+    let op = store.get_by_idempotency_key(&key).await.unwrap().unwrap();
+    assert!(is_submitted(op.current_step.as_ref()));
 }
 
 /// Rejection is terminal: a later sweep must not query the chain again, which is

--- a/gateway/store/tests/driver_recovery.rs
+++ b/gateway/store/tests/driver_recovery.rs
@@ -619,12 +619,17 @@ async fn reconcile_rejects_an_unrecorded_transaction_only_past_the_horizon(
 async fn an_abandoned_preparation_leaves_the_plan_intact(#[case] mut op: StoredOperation) {
     let store: SharedOperationStore = Arc::new(MemoryStore::new());
     let queued_before = op.remaining_steps.len();
-    let current_before = op.current_step.is_some();
+    // The variant, not just occupancy: swapping `Prepared` for another step is
+    // exactly the silent corruption this guards against.
+    let prepared_before = matches!(op.current_step, Some(CurrentStep::Prepared { .. }));
 
     drop(op.begin_next_preparation(store));
 
     assert_eq!(op.remaining_steps.len(), queued_before);
-    assert_eq!(op.current_step.is_some(), current_before);
+    assert_eq!(
+        matches!(op.current_step, Some(CurrentStep::Prepared { .. })),
+        prepared_before
+    );
 }
 
 /// Age alone must not reject. Without an archival node confirming it, a missing

--- a/gateway/store/tests/driver_recovery.rs
+++ b/gateway/store/tests/driver_recovery.rs
@@ -26,8 +26,8 @@ use rstest::rstest;
 use templar_gateway_core::{
     CompletedStep, CreateOperationResult, CurrentStep, ExecuteOperation, GatewayError,
     GatewayResult, OperationDriver, OperationPlan, OperationStore, PlannedTransaction,
-    PooledSigner, PreparedTransactionResult, SignTransaction, SigningKeyLease, StepOutcome,
-    StoredOperation, SucceededStep,
+    PooledSigner, PreparedTransactionResult, SharedOperationStore, SignTransaction,
+    SigningKeyLease, StepOutcome, StoredOperation, SucceededStep, TransactionRecord,
 };
 use templar_gateway_store::MemoryStore;
 use templar_gateway_types::{
@@ -90,10 +90,16 @@ fn fresh_submitted_step() -> CurrentStep {
     submitted_step_at(Utc::now())
 }
 
-/// A step submitted long ago. `UNKNOWN_TRANSACTION` is still not proof that it
-/// never landed, so this remains recoverable rather than rejected.
+/// A step submitted long ago but still inside the validity horizon, where
+/// `UNKNOWN_TRANSACTION` is not yet proof that it never landed.
 fn aged_submitted_step() -> CurrentStep {
     submitted_step_at(Utc::now() - TimeDelta::seconds(600))
+}
+
+/// A step submitted past the validity horizon, where the transaction can no
+/// longer be applied and the chain having no record of it becomes proof.
+fn expired_submitted_step() -> CurrentStep {
+    submitted_step_at(Utc::now() - TimeDelta::hours(49))
 }
 
 /// A planned operation with a single pending step and no remaining or succeeded steps.
@@ -104,6 +110,12 @@ fn step_op(step: CurrentStep) -> StoredOperation {
 /// An unknown transaction may still have landed, so its step is left submitted.
 fn is_submitted(step: Option<&CurrentStep>) -> bool {
     matches!(step, Some(CurrentStep::Submitted { .. }))
+}
+
+/// Past the horizon the transaction can never land, so its step is terminal and
+/// carries no outcome — releasing the charge.
+fn is_rejected(step: Option<&CurrentStep>) -> bool {
+    matches!(step, Some(CurrentStep::Rejected { .. }))
 }
 
 fn pool_secret_key(index: u8) -> SecretKey {
@@ -164,14 +176,6 @@ impl SignTransaction for FakeSigner {
         Ok(self.pool.lease_next().await)
     }
 
-    async fn lease_signing_key(
-        &self,
-        _signer_account_id: &ManagedAccountId,
-        public_key: &PublicKey,
-    ) -> Option<SigningKeyLease> {
-        self.pool.lease(public_key).await
-    }
-
     async fn sign_transaction(
         &self,
         lease: &SigningKeyLease,
@@ -197,7 +201,7 @@ impl SignTransaction for FakeSigner {
 #[derive(Default)]
 struct FakeExecutor {
     submits: Mutex<VecDeque<GatewayResult<Option<StepOutcome>>>>,
-    queries: Mutex<VecDeque<GatewayResult<StepOutcome>>>,
+    queries: Mutex<VecDeque<GatewayResult<TransactionRecord>>>,
 }
 
 #[derive(Default)]
@@ -254,11 +258,11 @@ impl ExecuteOperation for ProbeExecutor {
         &self,
         _signer: &ManagedAccountId,
         _tx_hash: CryptoHash,
-    ) -> GatewayResult<StepOutcome> {
+    ) -> GatewayResult<TransactionRecord> {
         self.probe.enter_query();
         sleep(self.query_delay).await;
         self.probe.exit_query();
-        Ok(step_outcome(true))
+        Ok(TransactionRecord::Executed(step_outcome(true)))
     }
 }
 
@@ -344,7 +348,7 @@ impl ExecuteOperation for BroadcastExecutor {
         &self,
         _signer: &ManagedAccountId,
         _tx_hash: CryptoHash,
-    ) -> GatewayResult<StepOutcome> {
+    ) -> GatewayResult<TransactionRecord> {
         panic!("unexpected query_transaction")
     }
 }
@@ -352,7 +356,7 @@ impl ExecuteOperation for BroadcastExecutor {
 impl FakeExecutor {
     fn new(
         submits: Vec<GatewayResult<Option<StepOutcome>>>,
-        queries: Vec<GatewayResult<StepOutcome>>,
+        queries: Vec<GatewayResult<TransactionRecord>>,
     ) -> Self {
         Self {
             submits: Mutex::new(submits.into()),
@@ -378,7 +382,7 @@ impl ExecuteOperation for FakeExecutor {
         &self,
         _signer: &ManagedAccountId,
         _tx_hash: CryptoHash,
-    ) -> GatewayResult<StepOutcome> {
+    ) -> GatewayResult<TransactionRecord> {
         self.queries
             .lock()
             .unwrap()
@@ -551,7 +555,10 @@ async fn reconcile_resolves_submitted_step(
 ) {
     let store = Arc::new(MemoryStore::new());
     let key = seed_keyed(&store, "sub", step_op(fresh_submitted_step())).await;
-    let executor = FakeExecutor::new(vec![], vec![Ok(step_outcome(is_success))]);
+    let executor = FakeExecutor::new(
+        vec![],
+        vec![Ok(TransactionRecord::Executed(step_outcome(is_success)))],
+    );
 
     let record = driver(store.clone(), executor)
         .reconcile_operation(&key)
@@ -569,21 +576,24 @@ async fn reconcile_resolves_submitted_step(
     }
 }
 
-/// Reconciling an unknown (chain-has-no-record) submitted transaction leaves it
-/// submitted regardless of age: NEAR `UNKNOWN_TRANSACTION` is not proof that it
-/// never landed, so the ambiguity must remain recoverable.
+/// A submitted transaction the chain has no record of stays submitted while it
+/// could still land, because `UNKNOWN_TRANSACTION` is not proof that it never
+/// did. Past the validity horizon the transaction can no longer be applied, so
+/// the same answer becomes proof and the step is rejected rather than re-queried
+/// forever.
 #[rstest]
 #[case::fresh(fresh_submitted_step(), OperationStatus::InProgress, is_submitted)]
 #[case::aged(aged_submitted_step(), OperationStatus::InProgress, is_submitted)]
+#[case::expired(expired_submitted_step(), OperationStatus::Failed, is_rejected)]
 #[tokio::test]
-async fn reconcile_keeps_unknown_submitted_transaction_recoverable(
+async fn reconcile_rejects_an_unrecorded_transaction_only_past_the_horizon(
     #[case] step: CurrentStep,
     #[case] expected_status: OperationStatus,
     #[case] expected_step: fn(Option<&CurrentStep>) -> bool,
 ) {
     let store = Arc::new(MemoryStore::new());
     let key = seed_keyed(&store, "sub", step_op(step)).await;
-    let executor = FakeExecutor::new(vec![], vec![Err(GatewayError::TransactionNotFound)]);
+    let executor = FakeExecutor::new(vec![], vec![Ok(TransactionRecord::NoRecord)]);
 
     let record = driver(store.clone(), executor)
         .reconcile_operation(&key)
@@ -593,6 +603,75 @@ async fn reconcile_keeps_unknown_submitted_transaction_recoverable(
     assert_eq!(record.status, expected_status);
     let op = store.get_by_idempotency_key(&key).await.unwrap().unwrap();
     assert!(expected_step(op.current_step.as_ref()));
+}
+
+/// A preparation abandoned part-way — a signing failure, an early return — must
+/// leave the operation exactly as it was. A step held in neither `current_step`
+/// nor `remaining_steps` would be silently dropped from the plan.
+#[rstest]
+#[case::re_signing_a_prepared_step(step_op(CurrentStep::Prepared {
+    transaction: sample_transaction(),
+    signed_transaction: Box::new(dummy_signed_transaction(pool_public_key(0), 42)),
+    tx_hash: CryptoHash(NearCryptoHash::default()),
+}))]
+#[case::signing_a_queued_step(stored(true, None, vec![sample_transaction()], vec![]))]
+#[tokio::test]
+async fn an_abandoned_preparation_leaves_the_plan_intact(#[case] mut op: StoredOperation) {
+    let store: SharedOperationStore = Arc::new(MemoryStore::new());
+    let queued_before = op.remaining_steps.len();
+    let current_before = op.current_step.is_some();
+
+    drop(op.begin_next_preparation(store));
+
+    assert_eq!(op.remaining_steps.len(), queued_before);
+    assert_eq!(op.current_step.is_some(), current_before);
+}
+
+/// Rejection is terminal: a later sweep must not query the chain again, which is
+/// what stops orphans accumulating work on every restart. The executor is given
+/// a single canned answer, so a second query panics.
+#[tokio::test]
+async fn a_rejected_step_is_not_requeried_on_a_later_pass() {
+    let store = Arc::new(MemoryStore::new());
+    let key = seed_keyed(&store, "expired", step_op(expired_submitted_step())).await;
+    let driver = driver(
+        store.clone(),
+        FakeExecutor::new(vec![], vec![Ok(TransactionRecord::NoRecord)]),
+    );
+
+    driver.reconcile_operation(&key).await.unwrap().unwrap();
+    let record = driver.reconcile_operation(&key).await.unwrap().unwrap();
+
+    assert_eq!(record.status, OperationStatus::Failed);
+    let op = store.get_by_idempotency_key(&key).await.unwrap().unwrap();
+    assert!(is_rejected(op.current_step.as_ref()));
+}
+
+/// Startup recovery over a store of nothing but past-horizon orphans completes
+/// clean and leaves nothing incomplete — the prod backlog this rule exists for.
+#[tokio::test]
+async fn startup_recovery_clears_a_backlog_of_expired_orphans() {
+    let store = Arc::new(MemoryStore::new());
+    for index in 0..3 {
+        let mut op = step_op(expired_submitted_step());
+        op.id = OperationId(format!("orphan-{index}"));
+        store.save_operation(op).await.unwrap();
+    }
+    let executor = FakeExecutor::new(
+        vec![],
+        vec![
+            Ok(TransactionRecord::NoRecord),
+            Ok(TransactionRecord::NoRecord),
+            Ok(TransactionRecord::NoRecord),
+        ],
+    );
+
+    driver(store.clone(), executor)
+        .resume_incomplete_operations()
+        .await
+        .unwrap();
+
+    assert!(store.list_incomplete_operations().await.unwrap().is_empty());
 }
 
 #[tokio::test]
@@ -619,13 +698,13 @@ async fn transient_query_error_leaves_step_submitted() {
     ));
 }
 
-/// Startup recovery is self-sufficient, but an unknown submitted step remains
-/// recoverable regardless of age because `UNKNOWN_TRANSACTION` is ambiguous.
+/// Startup recovery applies the same horizon rule as an on-demand reconcile.
 #[rstest]
 #[case::fresh(fresh_submitted_step(), is_submitted)]
 #[case::aged(aged_submitted_step(), is_submitted)]
+#[case::expired(expired_submitted_step(), is_rejected)]
 #[tokio::test]
-async fn startup_recovery_leaves_unknown_submitted_step_recoverable(
+async fn startup_recovery_rejects_an_unrecorded_step_only_past_the_horizon(
     #[case] step: CurrentStep,
     #[case] expected_step: fn(Option<&CurrentStep>) -> bool,
 ) {
@@ -633,7 +712,7 @@ async fn startup_recovery_leaves_unknown_submitted_step_recoverable(
     let mut op = step_op(step);
     op.id = OperationId("op".to_owned());
     store.save_operation(op.clone()).await.unwrap();
-    let executor = FakeExecutor::new(vec![], vec![Err(GatewayError::TransactionNotFound)]);
+    let executor = FakeExecutor::new(vec![], vec![Ok(TransactionRecord::NoRecord)]);
 
     driver(store.clone(), executor)
         .resume_incomplete_operations()
@@ -745,7 +824,7 @@ async fn reconcile_continues_remaining_steps_after_a_submitted_step_lands() {
     // query: step 1 landed; submit: step 2 is driven.
     let executor = FakeExecutor::new(
         vec![Ok(Some(step_outcome(true)))],
-        vec![Ok(step_outcome(true))],
+        vec![Ok(TransactionRecord::Executed(step_outcome(true)))],
     );
 
     let record = driver(store.clone(), executor)
@@ -941,15 +1020,12 @@ async fn pooled_keys_broadcast_in_parallel() {
     }
 }
 
-/// A step signed in an earlier pass carries a nonce bound to the key that signed
-/// it, so resubmission takes *that* key. Leasing a fresh one would let a new
-/// allocation — reading an on-chain nonce this step has not yet advanced — pick
-/// the same nonce.
-/// Holding that key's lane first is what proves the point: the key and nonce in
-/// the assertions come from the stored signature, so they hold even for a driver
-/// that broadcasts without taking a lane at all.
+/// A step signed in an earlier pass is re-signed, so it neither carries the old
+/// nonce to the network nor waits on the key that produced it. Holding that key's
+/// lane for the whole test proves the second half: an implementation that bound
+/// itself to the signing key would block here instead of finishing.
 #[tokio::test]
-async fn prepared_step_resubmits_under_the_key_that_signed_it() {
+async fn prepared_step_is_re_signed_without_waiting_on_its_original_key() {
     let store = Arc::new(MemoryStore::new());
     let log = Arc::new(BroadcastLog::default());
     let signer = Arc::new(FakeSigner::with_keys(2));
@@ -975,43 +1051,25 @@ async fn prepared_step_resubmits_under_the_key_that_signed_it() {
     );
     store.save_operation(op.clone()).await.unwrap();
 
-    let held = signer.pool.lease(&signing_key).await.expect("a pooled key");
-    let mut replay = tokio::spawn({
-        let driver = driver.clone();
-        async move { driver.execute_remaining_steps(op).await }
-    });
-
-    assert!(
-        timeout(Duration::from_millis(50), &mut replay)
-            .await
-            .is_err(),
-        "resubmission must wait for the lane of the key that signed the step"
-    );
-    assert_eq!(log.broadcasts(), 0);
-
-    drop(held);
-    let result = timeout(Duration::from_secs(5), replay)
+    let _held = signer.pool.lease(&signing_key).await.expect("a pooled key");
+    let result = timeout(Duration::from_secs(5), driver.execute_remaining_steps(op))
         .await
-        .expect("resubmission must proceed once the lane frees")
-        .unwrap()
+        .expect("re-signing must not wait on the original key's lane")
         .unwrap();
 
     assert_eq!(result.status(), OperationStatus::Succeeded);
-    assert_eq!(log.nonces_for(signing_key), vec![42]);
+    assert_eq!(log.nonces_for(pool_public_key(0)), vec![1]);
     assert!(
-        log.nonces_for(pool_public_key(0)).is_empty(),
-        "must not resign the step on a different key"
+        log.nonces_for(signing_key).is_empty(),
+        "the stored nonce must never reach the network"
     );
 }
 
-/// A key rotated out of the configuration since the step was signed leaves the
-/// stored signature valid on chain, and no lane here can allocate a nonce on
-/// that key — so recovery replays it rather than failing startup, and without
-/// taking a lane it does not need. Holding the pool's only lane for the
-/// duration proves the second half: an implementation that leased before
-/// replaying would block here instead of finishing.
+/// A step signed with a key the pool no longer holds is re-signed on a current
+/// one: nothing can allocate a nonce on a retired key, so replaying its stored
+/// signature would strand the step.
 #[tokio::test]
-async fn prepared_step_replays_under_a_key_the_pool_no_longer_holds() {
+async fn prepared_step_signed_with_a_retired_key_is_re_signed_on_a_current_one() {
     let store = Arc::new(MemoryStore::new());
     let log = Arc::new(BroadcastLog::default());
     let signer = Arc::new(FakeSigner::with_keys(1));
@@ -1023,7 +1081,6 @@ async fn prepared_step_replays_under_a_key_the_pool_no_longer_holds() {
             broadcast_delay: Duration::ZERO,
         }),
     );
-    let _lane = signer.pool.lease_next().await;
 
     let retired_key = pool_public_key(7);
     let op = stored(
@@ -1040,9 +1097,13 @@ async fn prepared_step_replays_under_a_key_the_pool_no_longer_holds() {
 
     let result = timeout(Duration::from_secs(5), driver.execute_remaining_steps(op))
         .await
-        .expect("replay must not wait on a lane")
+        .expect("a retired signing key must not strand the step")
         .unwrap();
 
     assert_eq!(result.status(), OperationStatus::Succeeded);
-    assert_eq!(log.nonces_for(retired_key), vec![42]);
+    assert_eq!(log.nonces_for(pool_public_key(0)), vec![1]);
+    assert!(
+        log.nonces_for(retired_key).is_empty(),
+        "the retired key's stored signature must never reach the network"
+    );
 }

--- a/service/gateway/src/config.rs
+++ b/service/gateway/src/config.rs
@@ -15,10 +15,19 @@ use templar_gateway_store::{MemoryStore, PostgresStore};
 use templar_gateway_types::ManagedAccountId;
 use url::Url;
 
-/// Whether this endpoint would be sent an API key, explicitly configured or
-/// carried in the URL's own `apiKey` query parameter.
-fn carries_api_key(rpc_url: &Url, explicit_api_key: bool) -> bool {
-    explicit_api_key || rpc_url.query_pairs().any(|(key, _)| key == "apiKey")
+/// The URLs a network will actually request. Any embedded `apiKey` has already
+/// been moved to the header by the builder, and HTTP requests never send a
+/// fragment, so two URLs differing only in those reach the same node.
+fn request_targets(network: &NetworkConfig) -> Vec<Url> {
+    network
+        .rpc_endpoints
+        .iter()
+        .map(|endpoint| {
+            let mut url = endpoint.url.clone();
+            url.set_fragment(None);
+            url
+        })
+        .collect()
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -142,36 +151,43 @@ impl Config {
             .near_rpc_api_key
             .as_ref()
             .map(|key| key.as_ref().to_owned());
+        let build = |name: &str, rpc_url: Url| {
+            NetworkConfigBuilder::from_url(name, rpc_url)
+                .api_key(api_key.clone())
+                .build()
+        };
 
-        for rpc_url in [
-            Some(&self.near_rpc_url),
-            self.near_archival_rpc_url.as_ref(),
+        let network = build("gateway", self.near_rpc_url.clone());
+        let archival_network = self
+            .near_archival_rpc_url
+            .clone()
+            .map(|rpc_url| build("gateway-archival", rpc_url));
+
+        // Validate the endpoints as they will be requested rather than the URLs
+        // as written: the builder moves an embedded `apiKey` onto the header, so
+        // only the built form shows what actually travels, and where.
+        for (flag, network) in [
+            ("--near-rpc-url", Some(&network)),
+            ("--near-archival-rpc-url", archival_network.as_ref()),
         ]
         .into_iter()
-        .flatten()
+        .filter_map(|(flag, network)| network.map(|network| (flag, network)))
         {
-            if carries_api_key(rpc_url, api_key.is_some()) && rpc_url.scheme() != "https" {
-                bail!(
-                    "RPC endpoint {} carries an API key and must use https://, or the key travels in cleartext",
-                    rpc_url
-                );
+            if network.rpc_endpoints.iter().any(|endpoint| {
+                endpoint.bearer_header.is_some() && endpoint.url.scheme() != "https"
+            }) {
+                // Deliberately without the URL: it may carry the key it is being
+                // rejected for exposing.
+                bail!("{flag} carries an API key and must use https://, or the key travels in cleartext");
             }
         }
 
-        if self.near_archival_rpc_url.as_ref() == Some(&self.near_rpc_url) {
-            bail!(
-                "--near-archival-rpc-url must differ from --near-rpc-url: an archival endpoint exists to answer what the primary has garbage collected"
-            );
+        if archival_network
+            .as_ref()
+            .is_some_and(|archival| request_targets(archival) == request_targets(&network))
+        {
+            bail!("--near-archival-rpc-url must differ from --near-rpc-url: an archival endpoint exists to answer what the primary has garbage collected");
         }
-
-        let network = NetworkConfigBuilder::from_url("gateway", self.near_rpc_url.clone())
-            .api_key(api_key.clone())
-            .build();
-        let archival_network = self.near_archival_rpc_url.clone().map(|rpc_url| {
-            NetworkConfigBuilder::from_url("gateway-archival", rpc_url)
-                .api_key(api_key.clone())
-                .build()
-        });
 
         Ok((network, archival_network))
     }
@@ -288,6 +304,20 @@ mod tests {
         ],
         Err("must use https://")
     )]
+    #[case::archival_differs_only_by_fragment(
+        &[
+            "--near-rpc-url", "https://rpc.example.com/",
+            "--near-archival-rpc-url", "https://rpc.example.com/#archival",
+        ],
+        Err("must differ from --near-rpc-url")
+    )]
+    #[case::archival_differs_only_by_api_key(
+        &[
+            "--near-rpc-url", "https://rpc.example.com/",
+            "--near-archival-rpc-url", "https://rpc.example.com/?apiKey=SECRET",
+        ],
+        Err("must differ from --near-rpc-url")
+    )]
     #[case::archival_same_as_primary(
         &[
             "--near-rpc-url", "https://rpc.example.com/",
@@ -320,6 +350,29 @@ mod tests {
                 panic!("invalid network config should fail with {expected_msg:?}")
             }
         }
+    }
+
+    /// The rejection exists to stop a key travelling in cleartext, so the
+    /// rejection must not print it either.
+    #[test]
+    fn insecure_endpoint_error_excludes_the_api_key() {
+        let config = Config::try_parse_from([
+            "templar-gateway-service",
+            "--near-rpc-url",
+            "http://rpc.example.com/?apiKey=SUPERSECRET",
+        ])
+        .expect("config should parse");
+
+        let error = config
+            .build_networks()
+            .expect_err("plaintext endpoint carrying a key must be rejected")
+            .to_string();
+
+        assert!(
+            !error.contains("SUPERSECRET"),
+            "error leaked the key: {error}"
+        );
+        assert!(error.contains("--near-rpc-url"));
     }
 
     #[rstest]

--- a/service/gateway/src/config.rs
+++ b/service/gateway/src/config.rs
@@ -7,11 +7,19 @@ use anyhow::{bail, Context, Result};
 use clap::Parser;
 use near_account_id::AccountId;
 use near_api::types::SecretKey;
+use near_api::NetworkConfig;
+use templar_gateway_client::NetworkConfigBuilder;
 use templar_gateway_core::{PooledSigner, RedactedString, SharedOperationStore};
 use templar_gateway_oracle_updates_dispatch::OracleSourceArgs;
 use templar_gateway_store::{MemoryStore, PostgresStore};
 use templar_gateway_types::ManagedAccountId;
 use url::Url;
+
+/// Whether this endpoint would be sent an API key, explicitly configured or
+/// carried in the URL's own `apiKey` query parameter.
+fn carries_api_key(rpc_url: &Url, explicit_api_key: bool) -> bool {
+    explicit_api_key || rpc_url.query_pairs().any(|(key, _)| key == "apiKey")
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ManagedSignerConfig {
@@ -67,8 +75,11 @@ pub struct Config {
     pub near_rpc_url: Url,
 
     /// Archival NEAR RPC endpoint, queried when the primary has no record of a
-    /// transaction. Without one, reconciliation cannot tell a transaction that
-    /// never landed from one whose outcome the primary has garbage collected.
+    /// transaction. Must retain full history: pointing this at another primary
+    /// re-creates the very ambiguity it exists to settle, since a garbage
+    /// collected outcome is reported exactly like one that never existed.
+    /// Without an archival endpoint, reconciliation leaves such a transaction in
+    /// flight rather than terminally rejecting it.
     #[arg(long, env = "NEAR_ARCHIVAL_RPC_URL")]
     pub near_archival_rpc_url: Option<Url>,
 
@@ -113,6 +124,56 @@ impl Config {
         }
 
         Ok(signers)
+    }
+
+    /// Resolve the primary and archival NEAR networks.
+    ///
+    /// The archival endpoint is a separate config rather than a second entry on
+    /// the primary's, so near_api does not fail over to it for every RPC the
+    /// gateway makes.
+    ///
+    /// # Errors
+    /// Rejects the two configurations that are wrong on their face: an API key
+    /// paired with a plaintext endpoint, which would send the key in cleartext;
+    /// and an archival URL equal to the primary, which cannot corroborate what
+    /// the primary has garbage collected.
+    pub fn build_networks(&self) -> Result<(NetworkConfig, Option<NetworkConfig>)> {
+        let api_key = self
+            .near_rpc_api_key
+            .as_ref()
+            .map(|key| key.as_ref().to_owned());
+
+        for rpc_url in [
+            Some(&self.near_rpc_url),
+            self.near_archival_rpc_url.as_ref(),
+        ]
+        .into_iter()
+        .flatten()
+        {
+            if carries_api_key(rpc_url, api_key.is_some()) && rpc_url.scheme() != "https" {
+                bail!(
+                    "RPC endpoint {} carries an API key and must use https://, or the key travels in cleartext",
+                    rpc_url
+                );
+            }
+        }
+
+        if self.near_archival_rpc_url.as_ref() == Some(&self.near_rpc_url) {
+            bail!(
+                "--near-archival-rpc-url must differ from --near-rpc-url: an archival endpoint exists to answer what the primary has garbage collected"
+            );
+        }
+
+        let network = NetworkConfigBuilder::from_url("gateway", self.near_rpc_url.clone())
+            .api_key(api_key.clone())
+            .build();
+        let archival_network = self.near_archival_rpc_url.clone().map(|rpc_url| {
+            NetworkConfigBuilder::from_url("gateway-archival", rpc_url)
+                .api_key(api_key.clone())
+                .build()
+        });
+
+        Ok((network, archival_network))
     }
 
     pub async fn build_store(&self) -> Result<SharedOperationStore> {
@@ -202,6 +263,62 @@ mod tests {
         match config.build_store().await {
             Ok(_) => {}
             Err(error) => panic!("memory-backed default store should build: {error}"),
+        }
+    }
+
+    #[rstest]
+    #[case::plain_http_without_key(&["--near-rpc-url", "http://localhost:3030"], Ok(()))]
+    #[case::https_with_key(
+        &["--near-rpc-url", "https://rpc.example.com", "--near-rpc-api-key", "SECRET"],
+        Ok(())
+    )]
+    #[case::plain_http_with_explicit_key(
+        &["--near-rpc-url", "http://rpc.example.com", "--near-rpc-api-key", "SECRET"],
+        Err("must use https://")
+    )]
+    #[case::plain_http_with_embedded_key(
+        &["--near-rpc-url", "http://rpc.example.com/?apiKey=SECRET"],
+        Err("must use https://")
+    )]
+    #[case::plain_http_archival_with_key(
+        &[
+            "--near-rpc-url", "https://rpc.example.com",
+            "--near-archival-rpc-url", "http://archival.example.com",
+            "--near-rpc-api-key", "SECRET",
+        ],
+        Err("must use https://")
+    )]
+    #[case::archival_same_as_primary(
+        &[
+            "--near-rpc-url", "https://rpc.example.com/",
+            "--near-archival-rpc-url", "https://rpc.example.com/",
+        ],
+        Err("must differ from --near-rpc-url")
+    )]
+    #[case::distinct_archival(
+        &[
+            "--near-rpc-url", "https://rpc.example.com/",
+            "--near-archival-rpc-url", "https://archival.example.com/",
+        ],
+        Ok(())
+    )]
+    fn network_config_validation(#[case] extra_args: &[&str], #[case] expected: Result<(), &str>) {
+        let mut args = vec!["templar-gateway-service"];
+        args.extend_from_slice(extra_args);
+        let config = Config::try_parse_from(args).expect("config should parse");
+
+        match (expected, config.build_networks()) {
+            (Ok(()), Ok(_)) => {}
+            (Ok(()), Err(error)) => panic!("valid network config should build: {error}"),
+            (Err(expected_msg), Err(error)) => {
+                assert!(
+                    error.to_string().contains(expected_msg),
+                    "expected {expected_msg:?}, got {error}"
+                );
+            }
+            (Err(expected_msg), Ok(_)) => {
+                panic!("invalid network config should fail with {expected_msg:?}")
+            }
         }
     }
 

--- a/service/gateway/src/config.rs
+++ b/service/gateway/src/config.rs
@@ -66,7 +66,13 @@ pub struct Config {
     )]
     pub near_rpc_url: Url,
 
-    /// API key for the RPC endpoint, sent as an `Authorization` header. May also
+    /// Archival NEAR RPC endpoint, queried when the primary has no record of a
+    /// transaction. Without one, reconciliation cannot tell a transaction that
+    /// never landed from one whose outcome the primary has garbage collected.
+    #[arg(long, env = "NEAR_ARCHIVAL_RPC_URL")]
+    pub near_archival_rpc_url: Option<Url>,
+
+    /// API key for the RPC endpoints, sent as an `Authorization` header. May also
     /// be supplied as an `apiKey` query parameter on `--near-rpc-url`.
     #[arg(long, env = "NEAR_RPC_API_KEY")]
     pub near_rpc_api_key: Option<RedactedString>,

--- a/service/gateway/src/gateway_service.rs
+++ b/service/gateway/src/gateway_service.rs
@@ -1,6 +1,7 @@
 use std::{collections::HashMap, marker::PhantomData, sync::Arc};
 
 use actix::Addr;
+use near_api::NetworkConfig;
 use templar_gateway_core::{
     DispatchRead, GatewayContext, GatewayResult, HasNearClient, NearOperationExecutor,
     NearTransactionSigner, OperationDriver, PlanWrite, PooledSigner, SharedOperationStore,
@@ -31,10 +32,15 @@ impl<ContextType> GatewayService<ContextType>
 where
     ContextType: HasNearClient + Clone + Send + std::marker::Unpin + 'static,
 {
+    /// `archival_network` is what lets reconciliation terminally reject a
+    /// transaction the chain has no record of: without a retention-complete node
+    /// to confirm it, a primary answering `UNKNOWN_TRANSACTION` may simply have
+    /// garbage collected the outcome of a transaction that did execute.
     pub async fn spawn(
         context: ContextType,
         signers: HashMap<ManagedAccountId, PooledSigner>,
         store: SharedOperationStore,
+        archival_network: Option<NetworkConfig>,
     ) -> GatewayResult<Self> {
         let signer_count = signers.len();
 
@@ -42,7 +48,8 @@ where
         let finality_policy = near.finality_policy();
         let signer = NearTransactionSigner::new(near.network().clone(), signers);
         let executor =
-            NearOperationExecutor::with_finality_policy(near.network().clone(), finality_policy);
+            NearOperationExecutor::with_finality_policy(near.network().clone(), finality_policy)
+                .with_archival_network(archival_network);
         let driver = OperationDriver::new(store, Arc::new(signer), Arc::new(executor));
 
         let (runtime, read) = spawn_runtime(context.clone())?;
@@ -184,6 +191,7 @@ mod tests {
             context,
             gateway_signers,
             Arc::new(templar_gateway_store::MemoryStore::new()),
+            None,
         )
         .await?;
 

--- a/service/gateway/src/gateway_service.rs
+++ b/service/gateway/src/gateway_service.rs
@@ -47,9 +47,11 @@ where
         let near = context.near_client();
         let finality_policy = near.finality_policy();
         let signer = NearTransactionSigner::new(near.network().clone(), signers);
-        let executor =
-            NearOperationExecutor::with_finality_policy(near.network().clone(), finality_policy)
-                .with_archival_network(archival_network);
+        let executor = NearOperationExecutor::with_finality_policy(
+            near.network().clone(),
+            archival_network,
+            finality_policy,
+        );
         let driver = OperationDriver::new(store, Arc::new(signer), Arc::new(executor));
 
         let (runtime, read) = spawn_runtime(context.clone())?;

--- a/service/gateway/src/main.rs
+++ b/service/gateway/src/main.rs
@@ -25,6 +25,7 @@ async fn main() -> anyhow::Result<()> {
     let store = config.build_store().await?;
     let sources = config.oracle_sources.build(Network::Testnet.hermes_url())?;
     let network = NetworkConfigBuilder::from_url("gateway", config.near_rpc_url)
+        .archival_rpc_url(config.near_archival_rpc_url)
         .api_key(
             config
                 .near_rpc_api_key

--- a/service/gateway/src/main.rs
+++ b/service/gateway/src/main.rs
@@ -24,15 +24,20 @@ async fn main() -> anyhow::Result<()> {
     let signers = config.build_signers()?;
     let store = config.build_store().await?;
     let sources = config.oracle_sources.build(Network::Testnet.hermes_url())?;
+    let api_key = config
+        .near_rpc_api_key
+        .as_ref()
+        .map(|k| k.as_ref().to_owned());
     let network = NetworkConfigBuilder::from_url("gateway", config.near_rpc_url)
-        .archival_rpc_url(config.near_archival_rpc_url)
-        .api_key(
-            config
-                .near_rpc_api_key
-                .as_ref()
-                .map(|k| k.as_ref().to_owned()),
-        )
+        .api_key(api_key.clone())
         .build();
+    // A separate config, not an extra endpoint on the primary: near_api would
+    // otherwise fail over to the archival node for every RPC the gateway makes.
+    let archival_network = config.near_archival_rpc_url.map(|rpc_url| {
+        NetworkConfigBuilder::from_url("gateway-archival", rpc_url)
+            .api_key(api_key.clone())
+            .build()
+    });
     let context = GatewayContext::builder(network)
         .with_pyth_source(sources.pyth_hermes_url)
         .with_redstone_source(&sources.redstone_node_path)
@@ -42,7 +47,7 @@ async fn main() -> anyhow::Result<()> {
 
     tracing::info!("Pyth Lazer payload source enabled");
 
-    let service = GatewayService::spawn(context, signers, store).await?;
+    let service = GatewayService::spawn(context, signers, store, archival_network).await?;
 
     let server = ServerBuilder::default().build(config.listen_addr).await?;
     let local_addr = server.local_addr()?;

--- a/service/gateway/src/main.rs
+++ b/service/gateway/src/main.rs
@@ -6,7 +6,7 @@ mod rpc;
 use crate::rpc::attach_gateway;
 use clap::Parser;
 use jsonrpsee::server::ServerBuilder;
-use templar_gateway_client::{Network, NetworkConfigBuilder};
+use templar_gateway_client::Network;
 use templar_gateway_core::GatewayContext;
 use templar_gateway_oracle_updates_dispatch::GatewayContextBuilderOracleExt;
 use tokio::signal;
@@ -24,20 +24,7 @@ async fn main() -> anyhow::Result<()> {
     let signers = config.build_signers()?;
     let store = config.build_store().await?;
     let sources = config.oracle_sources.build(Network::Testnet.hermes_url())?;
-    let api_key = config
-        .near_rpc_api_key
-        .as_ref()
-        .map(|k| k.as_ref().to_owned());
-    let network = NetworkConfigBuilder::from_url("gateway", config.near_rpc_url)
-        .api_key(api_key.clone())
-        .build();
-    // A separate config, not an extra endpoint on the primary: near_api would
-    // otherwise fail over to the archival node for every RPC the gateway makes.
-    let archival_network = config.near_archival_rpc_url.map(|rpc_url| {
-        NetworkConfigBuilder::from_url("gateway-archival", rpc_url)
-            .api_key(api_key.clone())
-            .build()
-    });
+    let (network, archival_network) = config.build_networks()?;
     let context = GatewayContext::builder(network)
         .with_pyth_source(sources.pyth_hermes_url)
         .with_redstone_source(&sources.redstone_node_path)

--- a/service/gateway/src/rpc/tests.rs
+++ b/service/gateway/src/rpc/tests.rs
@@ -116,6 +116,7 @@ impl TestStack {
             context.clone(),
             harness.gateway_signers(),
             Arc::new(MemoryStore::new()),
+            None,
         )
         .await?;
 


### PR DESCRIPTION
Closes ENG-477. Supersedes ENG-643 (closed as duplicate).

A step left in `Submitted` was resolved only by querying the chain by tx hash, and any failure — including the chain reporting no such transaction — restored it to `Submitted`. That rule has no terminal case, so a transaction the chain will never report was re-queried forever: the operation never settled, its charge never released, and it reappeared in every startup sweep. Prod carries ~15 such orphans, re-processed on every gateway restart, which is why the backend runs a `RECOVERY_SOFT_DEADLINE_SECS=300` stopgap.

## The rule

A NEAR transaction's validity is bounded by its embedded block hash, so past that window "no record" stops being ambiguous and becomes proof. Reconciliation rejects such a step once it is older than 48h (2× the ~24h validity, margin for clock skew). `CurrentStep::Rejected` carries no `ExecutionOutcome` — that is how the charge is released, and `postgres.rs` already pinned that meaning.

## Making it unforgeable

The safety of the rule rests on never mistaking "we could not ask" for "the chain says no". That is now structural, not conventional:

- **`TransactionRecord::{Executed, NoRecord}` replaces `GatewayError::TransactionNotFound`.** The answer is a value an implementor must deliberately construct; a transport failure stays `Err`. The variant is deleted, so the conflation is no longer expressible.
- **`query_transaction` walks the endpoints itself.** near_api walks them too (`UnknownTransaction` is non-critical, `tx_rpc.rs:81`), but collapses the walk to a single last error — which can surface one endpoint's "no record" while an earlier one never answered. The local walk keeps them apart: an endpoint that failed to respond outranks another's `NoRecord`.
- **Retries stripped from the per-endpoint views.** near_api retries `UNKNOWN_TRANSACTION` through its full backoff before the answer can be classified — pure sleep, on every orphan of every sweep.
- **Archival endpoint wired end to end** (`--near-archival-rpc-url` / `NEAR_ARCHIVAL_RPC_URL`). Without one, a primary that has garbage collected an outcome answers "no record" for a transaction that did execute — the exact case ENG-477 documents (op `f75c9bae…`).

## The prepared-step path

Recovery also resubmitted a stored signed transaction for a `Prepared` step; signed more than ~24h earlier that yields `Expired` and lands in the same limbo. It is now re-signed.

`PreparedCurrentStep::submit` records `Submitted` **before** broadcasting, so a step persisted as `Prepared` provably never reached the network — its signature can be dropped with no double-submit risk, and no chain query is needed to establish that (the issue's "resolve the recorded tx hash first" turned out unnecessary). Re-signing lives in `begin_next_preparation`, the only route to a submittable step, so a stale signature is unreachable rather than discouraged.

That let `SigningTarget::Bound`, `StepLane::Unheld` and `SignTransaction::lease_signing_key` go — they existed solely to replay a stored signature on its original key. A step signed with a key since rotated out of the pool was previously unrecoverable and now re-signs on a current one.

## Tests

`transient_query_error_leaves_step_submitted` passes **unmodified** — the evidence the split is safe. Two tests that pinned the old replay contract were rewritten rather than deleted.

- fresh / aged / expired cases on both reconcile and startup recovery
- rejection is terminal: no re-query on a later pass
- a backlog of past-horizon orphans leaves nothing incomplete
- an abandoned preparation leaves the plan intact
- endpoint walk: all-agree → `NoRecord`; one unreachable → `Err`; no endpoints → `Err`
- an explicit API key reaches the archival endpoint

`just test-fast` across gateway core/store/client/service/methods-dispatch: 153 passed. `cargo fmt --all --check` and workspace clippy clean.

## Known gaps

- "Archival finds an outcome the primary garbage collected" is untested — needs a full `FinalExecutionOutcome` payload. Both error paths are covered.
- Status queries use `wait_until: Executed`, so nearcore waits server-side for a transaction that will never appear, up to the 15s client timeout. That is likely the real source of the "~15s per orphan" figure in the issue. Changing it affects how in-flight transactions are recorded, so it is deliberately out of scope here.
- `TRANSACTION_VALIDITY_HORIZON` is a const rather than config or a value read from `EXPERIMENTAL_protocol_config`'s `transaction_validity_period`.
- The endpoint walk duplicates a second hand-rolled walk in `client/chain.rs`, and `tx.get` still goes through the chain path so it gets neither the archival fallback nor the `NoRecord` distinction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/611)
<!-- Reviewable:end -->
