### PR TITLE
fix(ci): route the patch dry-run replay to the node gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,9 +113,10 @@ Notes:
 
 Several CI/test-infra files enumerate crates, contracts, or paths by hand. A feature change elsewhere easily leaves one stale, and the failure is silent — tests that never run, jobs that never trigger. When your change matches a trigger below, update the listed files in the _same_ change.
 
-- **Adding a node-backed test crate** (integration tests that need a `SandboxHarness`):
+- **Adding a node-backed test crate** (tests that need a `SandboxHarness`):
   - `justfile` — add the package to `sandbox_full_packages`; the sandbox filter and Cargo package boundary are both derived from that list. (`templar-gateway-service`'s node tests live in `src/` and are matched separately by module path.)
   - `.github/workflows/test.yml` — add the crate's `src/**` and `tests/**` under the `changes` job's `near_integration` paths filter, or the test job won't trigger on changes to it.
+- **Adding a node-backed test inside a `src/` unit-test module**: the package list above selects `kind(test)` targets only, so name the test `requires_sandbox_*`. Without the prefix it stays in the fast gate, which runs no `neard` and installs no `cargo-near`.
 - **Adding or removing a contract / mock WASM**:
   - `contract/artifacts/src/ids.rs` — the `ArtifactId` enum and each artifact's name/path. `contract/artifacts/releases/` holds the released history, compiled in by `build.rs` (empty for mocks, which are never released). See `contract/artifacts/README.md`. This is the canonical list; `script/prebuild-test-contracts.sh` derives from it.
   - `gateway/testing/src/wasm.rs` — the `wasm_fns!` list, so the harness can load it.

--- a/contract/artifacts/src/workspace_loader.rs
+++ b/contract/artifacts/src/workspace_loader.rs
@@ -41,8 +41,11 @@ pub enum BuildContractError {
     BuildFailed,
 
     /// The `cargo near build` command exited with a non-zero status.
-    #[error("cargo near build failed with status: {status}")]
-    BuildStatus { status: std::process::ExitStatus },
+    #[error("cargo near build failed with status: {status}\n{stderr}")]
+    BuildStatus {
+        status: std::process::ExitStatus,
+        stderr: String,
+    },
 
     /// Failed to spawn or wait on the build process.
     #[error("Failed to execute cargo near build: {0}")]
@@ -170,12 +173,21 @@ pub fn build_artifact(
         .cloned()
         .ok_or_else(|| BuildContractError::PackageNotFound(package_name.to_string()))?;
 
-    let status = build_command(workspace_dir, package.manifest_path.as_str(), reproducible)
-        .status()
+    let mut child = build_command(workspace_dir, package.manifest_path.as_str(), reproducible)
+        .stderr(std::process::Stdio::piped())
+        .spawn()
         .map_err(BuildContractError::Io)?;
+    let captured = child.stderr.take().map_or_else(
+        || Ok(Vec::new()),
+        |pipe| tee_to_stderr(pipe).map_err(BuildContractError::Io),
+    )?;
+    let status = child.wait().map_err(BuildContractError::Io)?;
 
     if !status.success() {
-        return Err(BuildContractError::BuildStatus { status });
+        return Err(BuildContractError::BuildStatus {
+            status,
+            stderr: tail_lines(&String::from_utf8_lossy(&captured), STDERR_TAIL_LINES),
+        });
     }
 
     let target_name = resolve_target_name(&package);
@@ -209,6 +221,41 @@ fn configure_build_process_group(command: &mut std::process::Command) {
 
 #[cfg(all(feature = "clap", not(unix)))]
 fn configure_build_process_group(_command: &mut std::process::Command) {}
+
+/// How much of a failed build's stderr the error carries. The full stream is
+/// already on the terminal; this is the tail that names the cause.
+const STDERR_TAIL_LINES: usize = 20;
+
+/// Forward `pipe` to this process's stderr as it arrives, returning what passed
+/// through. Streaming matters: a reproducible build runs for minutes.
+fn tee_to_stderr(pipe: std::process::ChildStderr) -> std::io::Result<Vec<u8>> {
+    use std::io::{Read as _, Write as _};
+
+    let mut pipe = std::io::BufReader::new(pipe);
+    let mut sink = std::io::stderr().lock();
+    let mut captured = Vec::new();
+    let mut buffer = [0u8; 8192];
+    loop {
+        let read = pipe.read(&mut buffer)?;
+        if read == 0 {
+            break;
+        }
+        sink.write_all(&buffer[..read])?;
+        captured.extend_from_slice(&buffer[..read]);
+    }
+    sink.flush()?;
+    Ok(captured)
+}
+
+fn tail_lines(text: &str, lines: usize) -> String {
+    let mut tail: Vec<_> = text
+        .trim_end()
+        .rsplit_terminator('\n')
+        .take(lines)
+        .collect();
+    tail.reverse();
+    tail.join("\n")
+}
 
 fn build_command(
     workspace_dir: &Path,
@@ -258,5 +305,12 @@ mod tests {
         let path = Path::new("/ws").join(artifact.manifest_path());
 
         assert_eq!(path, Path::new("/ws/mock/ft/Cargo.toml"));
+    }
+
+    #[test]
+    fn stderr_tail_keeps_the_last_lines_in_order() {
+        assert_eq!(tail_lines("a\nb\nc\n", 2), "b\nc");
+        assert_eq!(tail_lines("a\nb", 5), "a\nb");
+        assert_eq!(tail_lines("", 5), "");
     }
 }

--- a/justfile
+++ b/justfile
@@ -26,8 +26,14 @@ templar-manager
 sandbox_gateway_package := 'templar-gateway-service'
 sandbox_packages := sandbox_full_packages + "\n" + sandbox_gateway_package
 sandbox_package_filter := 'package(' + replace(sandbox_full_packages, "\n", ') | package(') + ')'
+# `kind(test)` reaches integration targets only, so a node-backed test written as
+# a unit test inside a lib or bin is routed by its name instead. Scoped to the
+# sandbox packages: elsewhere the name would drop the test from both gates,
+# since the node gate only lists these packages.
+sandbox_name_filter := 'test(/(^|::)requires_sandbox_/)'
+sandbox_unit_filter := '((' + sandbox_package_filter + ') & ' + sandbox_name_filter + ')'
 sandbox_gateway_filter := 'package(' + sandbox_gateway_package + ') & (test(/^rpc::tests::/) | test(/^gateway_service::tests::/))'
-sandbox_filter := '((kind(test) & (' + sandbox_package_filter + ')) | (' + sandbox_gateway_filter + '))'
+sandbox_filter := '((kind(test) & (' + sandbox_package_filter + ')) | ' + sandbox_unit_filter + ' | (' + sandbox_gateway_filter + '))'
 fast_filter := 'not ' + network_filter + ' and not ' + sandbox_filter
 sandbox_test_filter := 'not ' + network_filter + ' and ' + sandbox_filter
 sandbox_test_threads := '4'

--- a/tools/manager/src/tests/patch.rs
+++ b/tools/manager/src/tests/patch.rs
@@ -231,7 +231,7 @@ fn proxy_migration_patch_declares_expected_views() {
     reason = "one integration scenario deliberately presents fixture setup, plan, replay, and stamp assertions together"
 )]
 #[tokio::test]
-async fn patch_dry_run_replays_proxy_v0_to_v1() -> Result<()> {
+async fn requires_sandbox_patch_dry_run_replays_proxy_v0_to_v1() -> Result<()> {
     let harness = templar_gateway_testing::SandboxHarness::start().await?;
     let account_id: AccountId = "proxy-oracle-ixlmustry-ixlmusdc.v1.tmplr.near".parse()?;
     let key: SecretKey = near_crypto::SecretKey::from_random(KeyType::ED25519)


### PR DESCRIPTION
`tests::patch::patch_dry_run_replays_proxy_v0_to_v1` fails in the Fast Tests partition, red on `dev` since 52b0f497 (#612).

```
thread 'tests::patch::patch_dry_run_replays_proxy_v0_to_v1' panicked at gateway/testing/src/wasm.rs:37:14:
failed to build contract artifact: BuildStatus { status: ExitStatus(unix_wait_status(25856)) }
```

## Diagnosis

`unix_wait_status(25856)` is exit 101 — cargo's `error: no such command: near`. Not a contract compile error: cargo-near's own build failures exit **1** (checked against a deliberately failing `cargo near build`). The Fast Tests job installs nextest and just, never `./.github/actions/cargo-near`, and never sets `TEST_CONTRACTS_PREBUILT`, so `wasm::get` takes the `build_artifact` branch and shells out to a cargo-near that isn't there.

One correction to the obvious reading: #612 *did* add `templar-manager` to `sandbox_full_packages`, but that entry was inert. The sandbox filter is `kind(test) & package(...)`, and `kind(test)` matches integration targets only — the test is a unit test in `src/`, so nothing selected it and it stayed in the fast partition. Confirmed with `cargo nextest list -p templar-manager` under each filter: 0 matches for `sandbox_filter`, listed under `fast_filter`.

Worth noting the test also starts a `neard`, so it never belonged in the fast gate regardless of the toolchain.

## Fix

**`justfile`** — route node-backed unit tests by name, mirroring the existing `requires_network_` idiom:

```just
sandbox_name_filter := 'test(/(^|::)requires_sandbox_/)'
sandbox_unit_filter := '((' + sandbox_package_filter + ') & ' + sandbox_name_filter + ')'
```

Scoped to the sandbox packages deliberately: the node gate narrows cargo to that package list, so an unscoped name match elsewhere would drop a test from *both* gates silently. Scoped, a misplaced test stays in the fast gate and fails loudly.

**`tools/manager/src/tests/patch.rs`** — renamed to `requires_sandbox_patch_dry_run_replays_proxy_v0_to_v1`.

Moving it to `tools/manager/tests/` was the alternative and would have needed no justfile change, but it drives `crate::cli`, `crate::context::build_context` and `crate::dispatch::dispatch`, all `pub(crate)`. Widening a binary crate's public API to satisfy a test-partition filter is the worse trade.

**`contract/artifacts/src/workspace_loader.rs`** — `BuildContractError::BuildStatus` now carries the subprocess's stderr, which would have made this a one-line diagnosis. `.status()` becomes a piped spawn with a tee: a reproducible build's minutes of progress still stream to the terminal (it backs the interactive `tools-common` build path), while the last 20 lines — where cargo-near puts the cause — reach the error.

**`AGENTS.md`** — the "Adding a node-backed test crate" checklist is what led to adding the package and stopping there. Added the `src/` unit-test case.

No `.github/workflows/test.yml` change needed: `tools/manager/src/**` is already in the `near_integration` paths filter, so the NEAR job triggers on this test.

## Verification

- Partition move: the test now lists under `sandbox_filter` and is absent from `fast_filter`; manager's other 374 fast tests are unmoved.
- `cargo nextest run -p templar-manager -E 'test(=tests::patch::requires_sandbox_patch_dry_run_replays_proxy_v0_to_v1)'` → PASS in 45.6s (owned-mode `neard`).
- `cargo clippy -p templar-contract-artifacts --tests -- -D warnings` clean; 19 artifacts tests pass including a new `tail_lines` case; `cargo fmt` run.

Full `just test-fast` not run locally — the filter change is purely additive to `sandbox_filter`, and `requires_sandbox_` matches exactly one test repo-wide, so nothing else can move. CI covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/616)
<!-- Reviewable:end -->
