### PR TITLE
fix(manager): stabilize patch replay test

### DIFF
--- a/tools/manager/src/tests/patch.rs
+++ b/tools/manager/src/tests/patch.rs
@@ -234,9 +234,10 @@ fn proxy_migration_patch_declares_expected_views() {
 async fn requires_sandbox_patch_dry_run_replays_proxy_v0_to_v1() -> Result<()> {
     let harness = templar_gateway_testing::SandboxHarness::start().await?;
     let account_id: AccountId = "proxy-oracle-ixlmustry-ixlmusdc.v1.tmplr.near".parse()?;
-    let key: SecretKey = near_crypto::SecretKey::from_random(KeyType::ED25519)
-        .to_string()
-        .parse()?;
+    let key: SecretKey =
+        near_crypto::SecretKey::from_seed(KeyType::ED25519, "proxy-oracle-v0-to-v1-signer")
+            .to_string()
+            .parse()?;
     let public_key: near_crypto::PublicKey = key.public_key().to_string().parse()?;
     let current_code = templar_gateway_testing::wasm::proxy_oracle().await.to_vec();
     let current_hash = CryptoHash::from(near_api::types::CryptoHash::hash(&current_code));
@@ -244,9 +245,10 @@ async fn requires_sandbox_patch_dry_run_replays_proxy_v0_to_v1() -> Result<()> {
         "../../../../contract/proxy-oracle/near/contract/tests/migration/mainnet_proxy_oracle_ixlmustry_ixlmusdc.borsh"
     ))?;
     let access_key = AccessKey::full_access();
-    let barrier_key: SecretKey = near_crypto::SecretKey::from_random(KeyType::ED25519)
-        .to_string()
-        .parse()?;
+    let barrier_key: SecretKey =
+        near_crypto::SecretKey::from_seed(KeyType::ED25519, "proxy-oracle-v0-to-v1-barrier")
+            .to_string()
+            .parse()?;
     let barrier_public_key: near_crypto::PublicKey =
         barrier_key.public_key().to_string().parse()?;
     let barrier_access_key = AccessKey::full_access();
@@ -290,6 +292,7 @@ async fn requires_sandbox_patch_dry_run_replays_proxy_v0_to_v1() -> Result<()> {
         ],
     )
     .await?;
+    templar_sandbox::wait_until_final(&network, &account_id, &public_key).await?;
     let remote = templar_gateway_client::Client::builder(network.clone())
         .secret_key(account_id.clone(), key.clone())?
         .build()?;


### PR DESCRIPTION
Stabilize the proxy-oracle patch dry-run sandbox replay against nextest retries.

- Use deterministic signer and barrier keys so a retry cannot accumulate access keys.
- Wait for the patched signer key to reach finality before submitting the first signed transaction.

Verification:
- `just test-sandbox -p templar-manager requires_sandbox_patch_dry_run_replays_proxy_v0_to_v1 --test-threads=1 --stale`
- `cargo fmt --all --check`
- `cargo clippy -p templar-manager --all-targets -- -D warnings`
- `git diff --check`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/617)
<!-- Reviewable:end -->
