### PR TITLE
fix(manager): isolate patch replay sandbox

### DIFF
--- a/tools/manager/src/tests/patch.rs
+++ b/tools/manager/src/tests/patch.rs
@@ -232,7 +232,7 @@ fn proxy_migration_patch_declares_expected_views() {
 )]
 #[tokio::test]
 async fn requires_sandbox_patch_dry_run_replays_proxy_v0_to_v1() -> Result<()> {
-    let harness = templar_gateway_testing::SandboxHarness::start().await?;
+    let harness = templar_gateway_testing::SandboxHarness::start_owned().await?;
     let account_id: AccountId = "proxy-oracle-ixlmustry-ixlmusdc.v1.tmplr.near".parse()?;
     let key: SecretKey =
         near_crypto::SecretKey::from_seed(KeyType::ED25519, "proxy-oracle-v0-to-v1-signer")


### PR DESCRIPTION
## Summary
- Run the state-patching proxy replay fixture on a dedicated sandbox node.
- Prevent its non-`.sandbox` account mutation from persisting into pooled-node siblings.

## Verification
- `just test-sandbox --stale -p templar-manager -E 'test(/requires_sandbox_patch_dry_run_replays_proxy_v0_to_v1/)'`
- `cargo fmt --all --check`
- `cargo clippy -p templar-manager --all-targets -- -D warnings`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/618)
<!-- Reviewable:end -->
