### PR TITLE
fix(soroban): report zero for empty Blend positions

### DIFF
--- a/contract/vault/soroban/blend-adapter/CHANGELOG.md
+++ b/contract/vault/soroban/blend-adapter/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Report zero assets when the adapter has no Blend supply position, keeping vault refreshes live
+  before first allocation and after a complete exit.
+
 ## [1.0.1](https://github.com/Templar-Protocol/contracts/compare/templar-soroban-blend-adapter-v1.0.0...templar-soroban-blend-adapter-v1.0.1) - 2026-08-03
 
 ### Added

--- a/contract/vault/soroban/blend-adapter/src/lib.rs
+++ b/contract/vault/soroban/blend-adapter/src/lib.rs
@@ -39,7 +39,7 @@ pub enum AdapterError {
     MissingConfig = 3,
     /// Arithmetic overflow when computing total assets.
     ArithmeticOverflow = 4,
-    /// No supply position found for the given reserve index.
+    /// Reserved for backward compatibility with the deployed error ABI.
     MissingPosition = 5,
     /// Arithmetic underflow when computing actual withdrawal.
     ArithmeticUnderflow = 6,
@@ -230,10 +230,8 @@ impl BlendAdapterContract {
         }
         let positions = client.get_positions(&env.current_contract_address());
         let index = reserve.config.index;
-        let b_tokens = positions
-            .supply
-            .get(index)
-            .ok_or(AdapterError::MissingPosition)?;
+        // Blend omits zero-valued positions from its sparse supply map.
+        let b_tokens = positions.supply.get(index).unwrap_or(0);
         b_tokens
             .checked_mul(reserve.data.b_rate)
             .and_then(|value| value.checked_div(SCALAR_12))

--- a/contract/vault/soroban/blend-adapter/tests/integration_tests.rs
+++ b/contract/vault/soroban/blend-adapter/tests/integration_tests.rs
@@ -13,9 +13,7 @@ use soroban_sdk::{
     token::StellarAssetClient,
     Address, BytesN, Env, String,
 };
-use templar_soroban_blend_adapter::{
-    AdapterError, BlendAdapterContract, BlendAdapterContractClient,
-};
+use templar_soroban_blend_adapter::{BlendAdapterContract, BlendAdapterContractClient};
 
 #[contract]
 struct DummyContract;
@@ -166,7 +164,7 @@ fn total_assets_returns_correct_value_after_supply() {
 }
 
 #[test]
-fn total_assets_missing_position_returns_error() {
+fn total_assets_without_position_returns_zero() {
     let env = Env::default();
     env.mock_all_auths();
     let (pool, _pool_client, asset, _asset_admin, _deployer) = setup_blend_pool(&env);
@@ -174,14 +172,12 @@ fn total_assets_missing_position_returns_error() {
     let vault = register_dummy_contract(&env);
     let (adapter, _admin, _client) = setup_adapter(&env, &pool, &vault);
 
-    // Query without supplying — call via env.as_contract since the client
-    // will panic on error; we want to verify the error type.
     env.as_contract(&adapter, || {
         let result = BlendAdapterContract::total_assets(env.clone(), asset.clone());
         assert_eq!(
             result,
-            Err(AdapterError::MissingPosition),
-            "should return MissingPosition when adapter has no pool position"
+            Ok(0),
+            "an adapter without a pool position should report zero assets"
         );
     });
 }
@@ -277,4 +273,8 @@ fn full_supply_withdraw_cycle() {
     // 4. Verify vault received assets
     let token_client = soroban_sdk::token::Client::new(&env, &asset);
     assert_eq!(token_client.balance(&vault), amount);
+
+    // Blend removes the supply-map entry after a complete exit. Absence means
+    // zero exposure, so the adapter must remain readable after withdrawing all.
+    assert_eq!(client.total_assets(&asset), 0);
 }

--- a/contract/vault/soroban/tests/blend_e2e.rs
+++ b/contract/vault/soroban/tests/blend_e2e.rs
@@ -241,6 +241,20 @@ fn vault_allocates_supply_to_blend_and_withdraws_back() {
         .unwrap();
     });
 
+    let refreshed_empty_external = env
+        .as_contract(&vault, || {
+            execute_command(
+                &env,
+                &VaultCommand::RefreshMarkets {
+                    caller: address_wire(&allocator),
+                    markets: vec![0u32],
+                },
+            )
+        })
+        .unwrap();
+    assert_eq!(refreshed_empty_external, 0);
+    assert_eq!(vault_snapshot(&env, &vault), (0, 0, 0));
+
     let deposit_amount = 10_000_000_000;
     let supply_amount = 6_000_000_000;
     let withdraw_amount = 2_500_000_000;


### PR DESCRIPTION
## Summary

- treat an absent Blend supply-map entry as zero exposure
- keep the existing `MissingPosition = 5` discriminant reserved for deployed ABI compatibility
- cover empty-adapter refreshes and reads after a complete Blend exit

## Bug

Blend stores account positions in sparse maps. Before an adapter supplies for the first time, and
after it withdraws its complete position, `positions.supply` has no entry for the reserve index.
That absence means the account has zero b-tokens.

The adapter instead converted the missing entry into `AdapterError::MissingPosition`:

```rust
positions.supply.get(index).ok_or(AdapterError::MissingPosition)?
```

The vault calls `total_assets` directly during `RefreshMarkets`, so the adapter error escalated
through the cross-contract call. A correctly configured but unused market therefore could not be
refreshed, and the same liveness failure could return after a complete market exit even though the
true external exposure was zero.

Initial allocation generally still worked because the supply call creates the Blend position
before the vault reads `total_assets`. This is a refresh/reconciliation liveness bug rather than a
deposit-accounting or current loss-of-funds bug.

## Fix

Use zero as the default b-token balance when the sparse map has no reserve entry. Reserve lookup,
staleness validation, and checked b-rate arithmetic remain unchanged.

## Regression coverage

- adapter with no prior supply reports `0`
- adapter remains readable and reports `0` after withdrawing its full position
- vault `RefreshMarkets` succeeds with zero external assets before first allocation

Before the implementation change, the adapter regression failed with
`left: Err(MissingPosition), right: Ok(0)`, and the vault regression failed with contract error
`#5`.

## Verification

- `cargo +1.89.0 fmt --all --check`
- `cargo +1.89.0 test -p templar-soroban-blend-adapter -- --nocapture` — 30 passed
- `cargo +1.89.0 test -p templar-soroban-runtime -- --nocapture` — 265 passed, 1 doc test ignored
- `cargo +1.89.0 clippy -p templar-soroban-blend-adapter -p templar-soroban-runtime --all-targets --all-features -- -D warnings`
- release Soroban target compilation for `templar-soroban-blend-adapter` on `wasm32v1-none`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/619)
<!-- Reviewable:end -->
