### PR TITLE
deploy(v1): ixlmdejaaa-ixlmusdc-2

### DIFF
--- a/deployments/v1/ixlmdejaaa-ixlmusdc-2.toml
+++ b/deployments/v1/ixlmdejaaa-ixlmusdc-2.toml
@@ -1,0 +1,28 @@
+extends = ["../profiles/v1.toml", "../profiles/v1-borrow-ixlmusdc.toml"]
+
+name = "ixlmdejaaa-ixlmusdc-2"
+
+[collateral]
+asset = "nep245:intents.near:nep245:v2_1.omni.hot.tg:1100_111bzQBB66Lr9d7WU1sDna78SqG5x1ZraFjkpPdiYXjHFRnZJUhuV"
+reference = { coin_gecko = { id = "defi-janus-henderson-anemoy-aaa-clo-fund" } }
+decimals = 18
+aggregator = "median_low"
+min_sources = 1
+sources = [
+    # Pyth Lazer has not yet enabled this feed
+    # { kind = "lazer", oracle = "pyth-lazer.v1.tmplr.near", feed_id = 1799, weight = 3 },
+    # { kind = "pyth", oracle = "pyth-oracle.near", price_id = "5ca9c34d00214bf9416439970caf29eb7f379536fcb82ee21e7d7cf69acadf2a", weight = 1 },
+    { kind = "red_stone", oracle = "redstone-adapter.v1.tmplr.near", price_id = "deJAAA_FUNDAMENTAL/USD", weight = 5 },
+]
+
+[market]
+# Flat 3% up to the 90% kink, then straight up to 23% at full usage.
+interest_rate_strategy = { Piecewise = { base = "0.03", optimal = "0.9", rate_1 = "0", rate_2 = "2" } }
+mcr_maintenance = "1.07"
+mcr_liquidation = "1.05"
+maximum_usage_ratio = "0.99"
+liquidation_maximum_spread = "0.025"
+borrow_range = { minimum = "1 atom" }
+supply_range = { minimum = "0.04 tokens" }
+supply_withdrawal_range = { minimum = "0.04 tokens" }
+yield_weights = { supply = 19, static = { "revenue.tmplr.near" = 1 } }


### PR DESCRIPTION
A second deJAAA/USDC market on `v1.tmplr.near`. It is a copy of
`ixlmdejaaa-ixlmusdc-1` — same collateral, same borrow leg, same sources,
same MCRs and ranges — differing only in the borrow curve.

## The curve

`-1` is flat 3.3% at every usage level. `-2` is flat 3% up to a 90% kink,
then climbs to 23% at full usage:

```toml
interest_rate_strategy = { Piecewise = { base = "0.03", optimal = "0.9", rate_1 = "0", rate_2 = "2" } }
```

`rate_1 = 0` flattens the pre-kink leg, leaving `base` to set it; `rate_2 = 2`
spends the last 10 points of usage covering 0.03 → 0.23. Values below are from
`Piecewise::at`, not from algebra:

| usage | 0 | 0.5 | 0.89 | 0.9 | 0.95 | 0.99 | 1.0 |
|---|---|---|---|---|---|---|---|
| rate | 3% | 3% | 3% | 3% | 13% | 21% | 23% |

`maximum_usage_ratio` stays at `0.99`, inherited from `-1`, so 21% is the
highest rate reachable in practice and 23% is the curve's endpoint. Worth a
second look if the intent was for 23% to be attainable.

## Checks

`tmplrmgr spec check --offline` passes — 4 passed, 1 skipped for `--offline`.
It derives `ixlmdejaaa-ixlmusdc-2.v1.tmplr.near` plus the matching
`proxy-oracle-` and `proxy-gov-` accounts.

Nothing is deployed by this PR. The spec still has to go through
`tmplrmgr market plan` and `market apply`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QvYvnToSoY2za8weBmexBB

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/624)
<!-- Reviewable:end -->
