### PR TITLE
feat(market): expose supplier yield cash pool (ENG-665)

### DIFF
--- a/common/src/market/mod.rs
+++ b/common/src/market/mod.rs
@@ -26,6 +26,11 @@ pub struct BorrowAssetMetrics {
     pub deposited_active: BorrowAssetAmount,
     pub deposited_incoming: HashMap<u32, BorrowAssetAmount>,
     pub borrowed: BorrowAssetAmount,
+    /// Repaid interest and fees available to pay supplier yield. Caps the
+    /// yield leg of every withdrawal and is shared market-wide,
+    /// first-come-first-served.
+    #[serde(default)]
+    pub paid_to_fees: BorrowAssetAmount,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -142,6 +147,19 @@ mod tests {
         parsed
     }
 
+    fn borrow_asset_metrics_json(paid_to_fees: Option<Value>) -> Value {
+        let mut metrics = json!({
+            "available": "90",
+            "deposited_active": "100",
+            "deposited_incoming": { "7": "10" },
+            "borrowed": "10",
+        });
+        if let Some(paid_to_fees) = paid_to_fees {
+            metrics["paid_to_fees"] = paid_to_fees;
+        }
+        metrics
+    }
+
     #[test]
     fn deposit_msg_supply() {
         let msg = roundtrip(&json!("Supply"));
@@ -197,5 +215,45 @@ mod tests {
             panic!("expected Liquidate, got {msg:?}");
         };
         assert_eq!(*amount, None);
+    }
+
+    #[test]
+    fn borrow_asset_metrics_legacy_json() {
+        let metrics: BorrowAssetMetrics =
+            serde_json::from_value(borrow_asset_metrics_json(None)).unwrap();
+
+        assert_eq!(u128::from(metrics.available), 90);
+        assert_eq!(u128::from(metrics.deposited_active), 100);
+        assert_eq!(u128::from(metrics.deposited_incoming[&7]), 10);
+        assert_eq!(u128::from(metrics.borrowed), 10);
+        assert!(metrics.paid_to_fees.is_zero());
+    }
+
+    #[test]
+    fn borrow_asset_metrics_paid_to_fees_json() {
+        for expected_paid_to_fees in [0, u128::MAX] {
+            let paid_to_fees = expected_paid_to_fees.to_string();
+            let metrics: BorrowAssetMetrics =
+                serde_json::from_value(borrow_asset_metrics_json(Some(json!(paid_to_fees))))
+                    .unwrap();
+
+            assert_eq!(u128::from(metrics.paid_to_fees), expected_paid_to_fees);
+            assert_eq!(
+                serde_json::to_value(&metrics).unwrap()["paid_to_fees"],
+                paid_to_fees,
+            );
+        }
+    }
+
+    #[test]
+    fn borrow_asset_metrics_rejects_malformed_paid_to_fees() {
+        for paid_to_fees in [Value::Null, json!("not-an-amount")] {
+            assert!(
+                serde_json::from_value::<BorrowAssetMetrics>(borrow_asset_metrics_json(Some(
+                    paid_to_fees
+                ),))
+                .is_err()
+            );
+        }
     }
 }

--- a/contract/market/src/impl_market_external.rs
+++ b/contract/market/src/impl_market_external.rs
@@ -43,6 +43,7 @@ impl MarketExternalInterface for Contract {
                 .map(|incoming| (incoming.activate_at_snapshot_index, incoming.amount))
                 .collect(),
             borrowed: self.borrowed(),
+            paid_to_fees: self.borrow_asset_paid_to_fees,
         }
     }
 

--- a/contract/market/tests/happy_path.rs
+++ b/contract/market/tests/happy_path.rs
@@ -156,6 +156,17 @@ async fn test_happy(
         ),
         1100,
     );
+    let near = harness.gateway_client();
+    let market_client = near.market(market.market_id.clone());
+    assert_eq!(
+        u128::from(
+            market_client
+                .get_borrow_asset_metrics(())
+                .await?
+                .paid_to_fees
+        ),
+        0,
+    );
 
     // Repay in full.
     harness.repay(&borrow_user, &market, 1100, None).await?;
@@ -169,6 +180,18 @@ async fn test_happy(
         ),
         0,
     );
+    assert_eq!(
+        u128::from(
+            market_client
+                .get_borrow_asset_metrics(())
+                .await?
+                .paid_to_fees
+        ),
+        100,
+    );
+
+    // Advance beyond the fixture's 1 ms snapshot boundary before harvesting the repaid fee.
+    harness.fast_forward(10).await?;
 
     // The 100 origination fee is split 8/1/1 across supply / protocol / insurance.
 
@@ -213,6 +236,15 @@ async fn test_happy(
             .is_zero(),
         "supply position should carry no yield after withdrawing it all",
     );
+    assert_eq!(
+        u128::from(
+            market_client
+                .get_borrow_asset_metrics(())
+                .await?
+                .paid_to_fees
+        ),
+        20,
+    );
 
     // Withdraw the supplied principal (1100); the position then closes.
     let balance_before = harness
@@ -234,6 +266,15 @@ async fn test_happy(
         .get_supply_position(&market, &supply_user.0)
         .await?
         .is_none());
+    assert_eq!(
+        u128::from(
+            market_client
+                .get_borrow_asset_metrics(())
+                .await?
+                .paid_to_fees
+        ),
+        20,
+    );
 
     // Protocol and insurance static yield: 10 each, paid in the borrow asset and
     // touching only it.

--- a/docs/src/monitoring.md
+++ b/docs/src/monitoring.md
@@ -102,11 +102,13 @@ Using available view functions:
   near contract call-function as-read-only <market-address> get_borrow_asset_metrics json-args {} network-config mainnet now
   ```
 
-- **Supplier Yield Availability**: The yield leg of a supplier withdrawal is
-  bounded by `min(accrued_yield, paid_to_fees)`. The motivating minimum gate is
-  `min(accrued_yield, paid_to_fees) >= supply_withdrawal_range.minimum`; existing
-  eligibility checks still apply, and other withdrawals can consume the shared
-  pool before execution.
+- **Supplier Yield Availability**: `min(accrued_yield, paid_to_fees)` is the
+  largest yield-only request that can be paid without consuming principal. Such
+  a request meets the configured minimum only when
+  `min(accrued_yield, paid_to_fees) >= supply_withdrawal_range.minimum`. This is
+  not a general withdrawal-eligibility check: principal may cover the remainder
+  of a larger request. Existing eligibility checks still apply, and other
+  withdrawals can consume the shared pool before execution.
 
 - **Current Interest Rate**: Monitor current rate for supply positions
   ```bash

--- a/docs/src/monitoring.md
+++ b/docs/src/monitoring.md
@@ -51,6 +51,17 @@ Regular checks can be performed using:
    # List all deployed markets from registry
    near contract call-function as-read-only v1.tmplr.near list_deployments json-args '{"offset": 0, "count": 100}' network-config mainnet now
    ```
+
+   `paid_to_fees` is the decimal-string amount of repaid interest and fees
+   currently available to pay supplier yield. It is a market-wide,
+   first-come-first-served pool: it is not accrued yield, per-user reserved
+   cash, or a guarantee that a withdrawal will execute. A raw JSON response
+   that omits this field is from a legacy deployment and differs from an
+   upgraded market explicitly reporting `"0"`; Rust consumers deserialize an
+   omitted field as zero for compatibility and therefore lose that distinction.
+   The field appears on live markets only after a released version containing it
+   has been deployed or upgraded.
+
 2. **Oracle Health**: Verify price feed freshness and accuracy
    ```bash
    # Check oracle prices
@@ -90,6 +101,12 @@ Using available view functions:
   # Get borrow asset metrics to calculate utilization (borrowed / available)
   near contract call-function as-read-only <market-address> get_borrow_asset_metrics json-args {} network-config mainnet now
   ```
+
+- **Supplier Yield Availability**: The yield leg of a supplier withdrawal is
+  bounded by `min(accrued_yield, paid_to_fees)`. The motivating minimum gate is
+  `min(accrued_yield, paid_to_fees) >= supply_withdrawal_range.minimum`; existing
+  eligibility checks still apply, and other withdrawals can consume the shared
+  pool before execution.
 
 - **Current Interest Rate**: Monitor current rate for supply positions
   ```bash


### PR DESCRIPTION
## Summary

- expose the market-wide `borrow_asset_paid_to_fees` pool as `BorrowAssetMetrics.paid_to_fees`
- preserve deserialization of legacy market responses with `#[serde(default)]` while serializing explicit zero values
- verify the deployed view across borrow, repayment, supplier-yield withdrawal, and principal withdrawal (`0 → 100 → 20 → 20`)
- document shared-pool semantics, legacy omission, and the release/upgrade dependency

## Testing

- `cargo test -p templar-common --lib -- --nocapture`
- `just test-sandbox -p templar-market-contract --test happy_path`
- `just test-fast -p templar-market-contract`
- `just test-sandbox -p templar-market-contract`
- `cargo fmt --all --check`
- `source script/postgres-up.sh && cargo clippy -p templar-common -p templar-market-contract --all-targets -- -D warnings`
- `cargo check --target wasm32-unknown-unknown -p templar-market-contract`
- `git diff --check`

## Rollout

The field reaches live consumers only after a contract release and market upgrade; this PR performs neither.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/625)
<!-- Reviewable:end -->
