### PR TITLE
fix(manager): accept an ambient $SECRET_KEY in --print mode (ENG-692)

### DIFF
--- a/tools/manager/src/commands/signer.rs
+++ b/tools/manager/src/commands/signer.rs
@@ -107,7 +107,6 @@ impl SignerArgs {
 
     /// The warning for a credential the selected mode will not use.
     pub(crate) fn ignored_credential_warning(&self) -> Option<String> {
-        self.secret_key.as_ref()?;
         let mode = match (self.print, self.sign_with) {
             (Some(_), _) => "--print only plans the write, so nothing is signed",
             (None, Some(SigningBackend::Keychain)) => {
@@ -115,10 +114,13 @@ impl SignerArgs {
             }
             (None, None) => return None,
         };
-        Some(format!(
-            "{mode} for {}; the supplied --secret-key/$SECRET_KEY is ignored.",
-            self.signer_id,
-        ))
+        // Presence only: nothing derived from the key itself may reach a log.
+        self.secret_key.is_some().then(|| {
+            format!(
+                "{mode} for {}; the supplied --secret-key/$SECRET_KEY is ignored.",
+                self.signer_id,
+            )
+        })
     }
 
     /// The signer's public key, granted full access on accounts a deploy
@@ -391,7 +393,10 @@ mod tests {
         assert!(warns, "the credential this write signs with is not ignored");
         assert!(warning.contains("--secret-key/$SECRET_KEY"), "{warning}");
         assert!(warning.contains("signer.testnet"), "{warning}");
-        assert!(!warning.contains(SECRET), "secret leaked: {warning}");
+        assert!(
+            !warning.contains(SECRET),
+            "the warning must not echo the credential"
+        );
     }
 
     #[tokio::test]

--- a/tools/manager/src/commands/signer.rs
+++ b/tools/manager/src/commands/signer.rs
@@ -369,18 +369,20 @@ mod tests {
     /// Built rather than parsed: an ambient `SECRET_KEY` would otherwise decide
     /// the outcome of the cases that supply none.
     #[rstest::rstest]
-    #[case::plan_ignores_it(Some(PrintFormat::Json), None, true)]
-    #[case::keychain_ignores_it(None, Some(SigningBackend::Keychain), true)]
-    #[case::a_signed_write_uses_it(None, None, false)]
+    #[case::plan_ignores_it(Some(PrintFormat::Json), None, Some(SECRET), true)]
+    #[case::keychain_ignores_it(None, Some(SigningBackend::Keychain), Some(SECRET), true)]
+    #[case::a_signed_write_uses_it(None, None, Some(SECRET), false)]
+    #[case::a_plan_without_one(Some(PrintFormat::Json), None, None, false)]
     fn warns_only_for_a_credential_the_mode_will_not_use(
         #[case] print: Option<PrintFormat>,
         #[case] sign_with: Option<SigningBackend>,
+        #[case] secret_key: Option<&str>,
         #[case] warns: bool,
     ) {
         let signer = SignerArgs {
             signer_id: "signer.testnet".parse().expect("valid account"),
             sign_with,
-            secret_key: Some(SECRET.to_owned()),
+            secret_key: secret_key.map(str::to_owned),
             print,
             public_key: None,
         };

--- a/tools/manager/src/commands/signer.rs
+++ b/tools/manager/src/commands/signer.rs
@@ -1,5 +1,5 @@
-//! Per-operation signer inputs: clap selects either execution credentials or a
-//! plan-only output format on every write.
+//! Per-operation signer inputs: the account authorizing every write, and either
+//! the credential that signs it or the plan-only output format that replaces it.
 //!
 //! Credentials resolve to a signer rather than a [`SecretKey`], so a backend
 //! holding its key outside this process is expressible.
@@ -35,7 +35,7 @@ pub(crate) enum SigningBackend {
 }
 
 /// The account authorizing a write and either its execution credential or its
-/// plan-only output format. Clap enforces the credential-mode split.
+/// plan-only output format.
 ///
 /// `Debug` is hand-written to redact `secret_key`; do not derive it.
 #[derive(Args, Clone)]
@@ -64,7 +64,6 @@ pub struct SignerArgs {
         // `--sign-with` names only external backends, so its presence always
         // means some other credential source was chosen.
         required_unless_present_any = ["print", "sign_with"],
-        conflicts_with = "print",
     )]
     secret_key: Option<String>,
     /// Plan the write without executing it, then print the selected representation.
@@ -106,6 +105,22 @@ impl SignerArgs {
         self.print
     }
 
+    /// The warning for a credential the selected mode will not use.
+    pub(crate) fn ignored_credential_warning(&self) -> Option<String> {
+        self.secret_key.as_ref()?;
+        let mode = match (self.print, self.sign_with) {
+            (Some(_), _) => "--print only plans the write, so nothing is signed",
+            (None, Some(SigningBackend::Keychain)) => {
+                "--sign-with keychain signs with the key the keychain holds"
+            }
+            (None, None) => return None,
+        };
+        Some(format!(
+            "{mode} for {}; the supplied --secret-key/$SECRET_KEY is ignored.",
+            self.signer_id,
+        ))
+    }
+
     /// The signer's public key, granted full access on accounts a deploy
     /// creates. Only the in-process backend derives it locally.
     pub fn public_key(&self) -> anyhow::Result<PublicKey> {
@@ -132,7 +147,8 @@ impl SignerArgs {
         }
         if self.print.is_some() {
             anyhow::bail!(
-                "--public-key is required with --print for writes that embed the signer's key"
+                "--public-key is required with --print for writes that embed the signer's key. \
+                 --secret-key/$SECRET_KEY cannot stand in: a plan is signed by whoever executes it."
             );
         }
         if self.sign_with.is_some() {
@@ -155,22 +171,14 @@ impl SignerArgs {
         if self.print.is_some() {
             anyhow::bail!("--print is not supported for this orchestrated write");
         }
+        if let Some(warning) = self.ignored_credential_warning() {
+            tracing::warn!("{warning}");
+        }
 
         let signer = match self.sign_with {
             None => Signer::from_secret_key(self.secret()?.clone())
                 .context("build a signer from --secret-key")?,
             Some(SigningBackend::Keychain) => {
-                // Warned, not refused: clap's conflicts fire on env values, so
-                // exclusivity would break the documented keychain flow. The
-                // failure worth preventing is the *silence*.
-                if self.secret_key.is_some() {
-                    eprintln!(
-                        "warning: --sign-with keychain is set, so the supplied \
-                         --secret-key/$SECRET_KEY is ignored; this transaction \
-                         is signed by the key the keychain holds for {}.",
-                        self.signer_id,
-                    );
-                }
                 Signer::from_keystore_with_search_for_keys(self.signer_id.clone(), network)
                     .await
                     .context("find a usable key for this account in the OS keychain")?
@@ -354,6 +362,36 @@ mod tests {
             .is_err(),
             "print mode signs nothing, so a backend is a contradiction"
         );
+    }
+
+    /// Built rather than parsed: an ambient `SECRET_KEY` would otherwise decide
+    /// the outcome of the cases that supply none.
+    #[rstest::rstest]
+    #[case::plan_ignores_it(Some(PrintFormat::Json), None, true)]
+    #[case::keychain_ignores_it(None, Some(SigningBackend::Keychain), true)]
+    #[case::a_signed_write_uses_it(None, None, false)]
+    fn warns_only_for_a_credential_the_mode_will_not_use(
+        #[case] print: Option<PrintFormat>,
+        #[case] sign_with: Option<SigningBackend>,
+        #[case] warns: bool,
+    ) {
+        let signer = SignerArgs {
+            signer_id: "signer.testnet".parse().expect("valid account"),
+            sign_with,
+            secret_key: Some(SECRET.to_owned()),
+            print,
+            public_key: None,
+        };
+
+        let Some(warning) = signer.ignored_credential_warning() else {
+            assert!(!warns, "an unused credential must not pass silently");
+            return;
+        };
+
+        assert!(warns, "the credential this write signs with is not ignored");
+        assert!(warning.contains("--secret-key/$SECRET_KEY"), "{warning}");
+        assert!(warning.contains("signer.testnet"), "{warning}");
+        assert!(!warning.contains(SECRET), "secret leaked: {warning}");
     }
 
     #[tokio::test]

--- a/tools/manager/src/context.rs
+++ b/tools/manager/src/context.rs
@@ -140,6 +140,9 @@ impl CliContext {
         Dispatch: PlanWrite<S, GatewayContext>,
     {
         if let Some(format) = signer.print() {
+            if let Some(warning) = signer.ignored_credential_warning() {
+                tracing::warn!("{warning}");
+            }
             let plan = self
                 .client
                 .plan_request(WriteRequest {
@@ -170,6 +173,9 @@ impl CliContext {
         OracleUpdatesDispatch: PlanWrite<S, Ctx>,
     {
         if let Some(format) = signer.print() {
+            if let Some(warning) = signer.ignored_credential_warning() {
+                tracing::warn!("{warning}");
+            }
             let context = layer_sources(GatewayContext::new(self.network.clone())?)?;
             let plan = <OracleUpdatesDispatch as PlanWrite<S, Ctx>>::plan(
                 WriteRequest {

--- a/tools/manager/src/tests.rs
+++ b/tools/manager/src/tests.rs
@@ -216,6 +216,27 @@ fn write_fallback_does_not_require_a_lazer_key() {
     );
 }
 
+/// ENG-692: clap applies a conflict to an env-sourced value, so an arg that
+/// declares both fails whenever the variable happens to be exported. Asserted
+/// over clap's metadata, since only the exported shell reproduces it.
+#[test]
+fn no_argument_pairs_an_env_source_with_a_conflict() {
+    fn walk(command: &clap::Command, path: &str) {
+        for arg in command.get_arguments() {
+            assert!(
+                arg.get_env().is_none() || command.get_arg_conflicts_with(arg).is_empty(),
+                "`{path}` declares both an env source and a conflict on `{}`",
+                arg.get_id()
+            );
+        }
+        for sub in command.get_subcommands() {
+            walk(sub, &format!("{path} {}", sub.get_name()));
+        }
+    }
+
+    walk(&Cli::command(), "tmplrmgr");
+}
+
 #[test]
 fn write_requires_secret_key_or_print() {
     // Omitting both execution credentials and plan mode is a parse error, so no
@@ -319,8 +340,8 @@ fn write_command_accepts_print_without_secret() {
 }
 
 #[test]
-fn print_conflicts_with_secret_key() {
-    let error = try_parse_write([
+fn print_accepts_an_explicit_secret_key() {
+    let cli = try_parse_write([
         "--signer-id",
         "dao.near",
         "--print",
@@ -328,21 +349,27 @@ fn print_conflicts_with_secret_key() {
         "--secret-key",
         TEST_SECRET_KEY,
     ])
-    .expect_err("plan and execution credentials must be mutually exclusive");
+    .expect("plan-only write should accept an unused credential");
 
-    assert_eq!(error.kind(), clap::error::ErrorKind::ArgumentConflict);
+    let Command::Write(call) = cli.command else {
+        panic!("expected Write variant");
+    };
+    assert_eq!(call.signer.print(), Some(PrintFormat::Json));
 }
 
 #[test]
-fn print_conflicts_with_secret_key_from_environment() {
+fn print_accepts_a_secret_key_from_environment() {
     let _guard = ENV_LOCK.lock().expect("env lock should not be poisoned");
     let original_secret = std::env::var_os("SECRET_KEY");
     std::env::set_var("SECRET_KEY", TEST_SECRET_KEY);
     let result = try_parse_write(["--signer-id", "dao.near", "--print", "json"]);
     restore_env("SECRET_KEY", original_secret);
 
-    let error = result.expect_err("environment secret must conflict with --print");
-    assert_eq!(error.kind(), clap::error::ErrorKind::ArgumentConflict);
+    let cli = result.expect("an ambient secret must not block a plan-only write");
+    let Command::Write(call) = cli.command else {
+        panic!("expected Write variant");
+    };
+    assert_eq!(call.signer.print(), Some(PrintFormat::Json));
 }
 
 #[test]

--- a/tools/manager/src/tests.rs
+++ b/tools/manager/src/tests.rs
@@ -216,19 +216,44 @@ fn write_fallback_does_not_require_a_lazer_key() {
     );
 }
 
-/// ENG-692: clap applies a conflict to an env-sourced value, so an arg that
-/// declares both fails whenever the variable happens to be exported. Asserted
-/// over clap's metadata, since only the exported shell reproduces it.
+/// ENG-692: clap applies a conflict to an env-sourced value, so an argument
+/// that ends up on either side of one fails whenever the variable happens to be
+/// exported. Both endpoints are checked, since the conflict binds the pair no
+/// matter which of them declares it, as does a group that admits only one
+/// member. `overrides_with` has no public getter and is not covered.
 #[test]
 fn no_argument_pairs_an_env_source_with_a_conflict() {
     fn walk(command: &clap::Command, path: &str) {
+        let from_env: Vec<&clap::Id> = command
+            .get_arguments()
+            .filter(|arg| arg.get_env().is_some())
+            .map(clap::Arg::get_id)
+            .collect();
+
         for arg in command.get_arguments() {
-            assert!(
-                arg.get_env().is_none() || command.get_arg_conflicts_with(arg).is_empty(),
-                "`{path}` declares both an env source and a conflict on `{}`",
-                arg.get_id()
-            );
+            for conflict in command.get_arg_conflicts_with(arg) {
+                assert!(
+                    arg.get_env().is_none() && !from_env.contains(&conflict.get_id()),
+                    "`{path}` conflicts `{}` with `{}`, and one of them reads an env var",
+                    arg.get_id(),
+                    conflict.get_id(),
+                );
+            }
         }
+
+        for group in command.get_groups() {
+            if group.clone().is_multiple() {
+                continue;
+            }
+            for member in group.get_args() {
+                assert!(
+                    !from_env.contains(&member),
+                    "`{path}` puts the env-sourced `{member}` in the exclusive group `{}`",
+                    group.get_id(),
+                );
+            }
+        }
+
         for sub in command.get_subcommands() {
             walk(sub, &format!("{path} {}", sub.get_name()));
         }

--- a/tools/manager/src/tests/proxy_oracle.rs
+++ b/tools/manager/src/tests/proxy_oracle.rs
@@ -8,10 +8,7 @@ use near_sdk::Gas;
 
 use templar_gateway_types::ProposalEncoding;
 
-use super::{
-    parse_create_proposal, parse_governance, try_parse_governance, with_cleared_credential_env,
-    CREDS,
-};
+use super::{parse_create_proposal, parse_governance, try_parse_governance, CREDS};
 use crate::cli::{Cli, Command};
 use crate::commands::{
     proxy_oracle::{ProxyOracleGovernanceNs, ProxyOracleNs},
@@ -654,49 +651,40 @@ fn execute_proposal_when_ready_flag() {
 
 #[test]
 fn governance_write_commands_accept_print_mode() {
-    let (execute, create) = with_cleared_credential_env(|| {
-        (
-            try_parse_governance([
-                "execute-proposal",
-                "--governance-id",
-                "gov.testnet",
-                "--id",
-                "2",
-                "--signer-id",
-                "dao.near",
-                "--print",
-                "sputnik",
-            ]),
-            try_parse_governance([
-                "create-proposal",
-                "--governance-id",
-                "gov.testnet",
-                "--id",
-                "0",
-                "--signer-id",
-                "dao.near",
-                "--print",
-                "json",
-                "oracle",
-                "call",
-                "--method",
-                "own_accept_owner",
-                "--deposit",
-                "1 yoctoNEAR",
-            ]),
-        )
-    });
-
-    let ProxyOracleGovernanceNs::ExecuteProposal(execute) =
-        execute.expect("immediate execution should support planning")
-    else {
+    let ProxyOracleGovernanceNs::ExecuteProposal(execute) = try_parse_governance([
+        "execute-proposal",
+        "--governance-id",
+        "gov.testnet",
+        "--id",
+        "2",
+        "--signer-id",
+        "dao.near",
+        "--print",
+        "sputnik",
+    ])
+    .expect("immediate execution should support planning") else {
         panic!("expected execute-proposal");
     };
     assert_eq!(execute.signer.print(), Some(PrintFormat::Sputnik));
 
-    let ProxyOracleGovernanceNs::CreateProposal(create) =
-        create.expect("single-write proposal creation should support planning")
-    else {
+    let ProxyOracleGovernanceNs::CreateProposal(create) = try_parse_governance([
+        "create-proposal",
+        "--governance-id",
+        "gov.testnet",
+        "--id",
+        "0",
+        "--signer-id",
+        "dao.near",
+        "--print",
+        "json",
+        "oracle",
+        "call",
+        "--method",
+        "own_accept_owner",
+        "--deposit",
+        "1 yoctoNEAR",
+    ])
+    .expect("single-write proposal creation should support planning") else {
         panic!("expected create-proposal");
     };
     assert_eq!(create.signer.print(), Some(PrintFormat::Json));
@@ -704,40 +692,36 @@ fn governance_write_commands_accept_print_mode() {
 
 #[test]
 fn proposal_orchestration_flags_conflict_with_print() {
-    let (execute, create) = with_cleared_credential_env(|| {
-        (
-            try_parse_governance([
-                "execute-proposal",
-                "--governance-id",
-                "gov.testnet",
-                "--id",
-                "2",
-                "--when-ready",
-                "--signer-id",
-                "dao.near",
-                "--print",
-                "json",
-            ]),
-            try_parse_governance([
-                "create-proposal",
-                "--governance-id",
-                "gov.testnet",
-                "--id",
-                "0",
-                "--execute-when-ready",
-                "--signer-id",
-                "dao.near",
-                "--print",
-                "json",
-                "oracle",
-                "call",
-                "--method",
-                "own_accept_owner",
-                "--deposit",
-                "1 yoctoNEAR",
-            ]),
-        )
-    });
+    let execute = try_parse_governance([
+        "execute-proposal",
+        "--governance-id",
+        "gov.testnet",
+        "--id",
+        "2",
+        "--when-ready",
+        "--signer-id",
+        "dao.near",
+        "--print",
+        "json",
+    ]);
+    let create = try_parse_governance([
+        "create-proposal",
+        "--governance-id",
+        "gov.testnet",
+        "--id",
+        "0",
+        "--execute-when-ready",
+        "--signer-id",
+        "dao.near",
+        "--print",
+        "json",
+        "oracle",
+        "call",
+        "--method",
+        "own_accept_owner",
+        "--deposit",
+        "1 yoctoNEAR",
+    ]);
 
     assert_eq!(
         execute

--- a/tools/manager/src/tests/registry.rs
+++ b/tools/manager/src/tests/registry.rs
@@ -5,7 +5,7 @@ use near_sdk::json_types::Base58CryptoHash;
 use serde_json::json;
 use templar_common::registry::VersionSource;
 
-use super::{with_cleared_credential_env, CREDS, TEST_SECRET_KEY};
+use super::{CREDS, TEST_SECRET_KEY};
 use crate::cli::{Cli, Command};
 use crate::commands::registry::RegistryNs;
 
@@ -464,30 +464,28 @@ fn add_version_requires_a_contract_source() {
 #[test]
 fn deploy_plan_uses_explicit_public_key() {
     let public_key = "ed25519:5TMKtTtD5uuMF28ovo7vVge7oAu58eXjySJWTrwcEB5w";
-    let result = with_cleared_credential_env(|| {
-        Cli::try_parse_from([
-            "tmplrmgr",
-            "registry",
-            "deploy",
-            "--registry-id",
-            "registry.testnet",
-            "--name",
-            "market",
-            "--version-key",
-            "market@1",
-            "--deposit",
-            "1 NEAR",
-            "--init-args",
-            "null",
-            "--signer-id",
-            "dao.near",
-            "--print",
-            "json",
-            "--public-key",
-            public_key,
-        ])
-    });
-    let cli = result.expect("plan-only deploy should parse");
+    let cli = Cli::try_parse_from([
+        "tmplrmgr",
+        "registry",
+        "deploy",
+        "--registry-id",
+        "registry.testnet",
+        "--name",
+        "market",
+        "--version-key",
+        "market@1",
+        "--deposit",
+        "1 NEAR",
+        "--init-args",
+        "null",
+        "--signer-id",
+        "dao.near",
+        "--print",
+        "json",
+        "--public-key",
+        public_key,
+    ])
+    .expect("plan-only deploy should parse");
     let Command::Registry {
         command: RegistryNs::Deploy(cmd),
     } = cli.command
@@ -505,29 +503,27 @@ fn deploy_plan_uses_explicit_public_key() {
 
 #[test]
 fn deploy_plan_without_signer_grant_needs_no_public_key() {
-    let result = with_cleared_credential_env(|| {
-        Cli::try_parse_from([
-            "tmplrmgr",
-            "registry",
-            "deploy",
-            "--registry-id",
-            "registry.testnet",
-            "--name",
-            "market",
-            "--version-key",
-            "market@1",
-            "--deposit",
-            "1 NEAR",
-            "--init-args",
-            "null",
-            "--no-signer-full-access-key",
-            "--signer-id",
-            "dao.near",
-            "--print",
-            "json",
-        ])
-    });
-    let cli = result.expect("plan-only deploy should parse");
+    let cli = Cli::try_parse_from([
+        "tmplrmgr",
+        "registry",
+        "deploy",
+        "--registry-id",
+        "registry.testnet",
+        "--name",
+        "market",
+        "--version-key",
+        "market@1",
+        "--deposit",
+        "1 NEAR",
+        "--init-args",
+        "null",
+        "--no-signer-full-access-key",
+        "--signer-id",
+        "dao.near",
+        "--print",
+        "json",
+    ])
+    .expect("plan-only deploy should parse");
     let Command::Registry {
         command: RegistryNs::Deploy(cmd),
     } = cli.command
@@ -601,20 +597,18 @@ fn remove_version_all_has_no_single_spec() {
 }
 #[test]
 fn remove_version_all_conflicts_with_print() {
-    let error = with_cleared_credential_env(|| {
-        Cli::try_parse_from([
-            "tmplrmgr",
-            "registry",
-            "remove-version",
-            "--registry-id",
-            "registry.testnet",
-            "--all",
-            "--signer-id",
-            "dao.near",
-            "--print",
-            "json",
-        ])
-    })
+    let error = Cli::try_parse_from([
+        "tmplrmgr",
+        "registry",
+        "remove-version",
+        "--registry-id",
+        "registry.testnet",
+        "--all",
+        "--signer-id",
+        "dao.near",
+        "--print",
+        "json",
+    ])
     .expect_err("--all must conflict with --print");
 
     assert_eq!(error.kind(), clap::error::ErrorKind::ArgumentConflict);


### PR DESCRIPTION
Closes ENG-692.

`SignerArgs::secret_key` declared both `env = "SECRET_KEY"` and `conflicts_with = "print"`. Clap applies conflicts to env-sourced values, so a shell that exports `SECRET_KEY` failed **every** `--print` invocation across every write subcommand — and exporting it is exactly what `contract/proxy-oracle/README.md:105` tells operators to do. The two documented practices could not be followed at once.

```
$ SECRET_KEY=ed25519:… tmplrmgr <write> --signer-id dao.near --print json
error: the argument '--secret-key <SECRET_KEY>' cannot be used with '--print <FORMAT>'
```

Print mode never reads the credential — `CliContext::write` returns from the plan branch and `resolve` bails on print — so the conflict was spurious, not protective.

## What changed

- **Dropped `conflicts_with = "print"` from `secret_key`.** `required_unless_present_any` is untouched; `--sign-with` × `--print` stays a hard conflict, since that argument has no env source.
- **Warn instead of refuse**, the way the keychain backend already did. The advisory is now shared rather than duplicated: `ignored_credential_warning` covers every mode that leaves the credential unused, and `resolve` calls it instead of carrying a second hand-written copy.
- **`tracing::warn!` rather than `eprintln!`**, so both paths honor `-q`. The old raw write ignored it, which matters for scripted `--print` loops running with a key exported (`-qqq` now silences it; it also reaches the file log).
- **A metadata guard** — `no_argument_pairs_an_env_source_with_a_conflict` walks the whole command tree and asserts no env-sourced argument ends up on either side of a conflict, including membership in a `multiple = false` group. Both endpoints are checked, because the conflict binds the pair regardless of which side declares it: declaring it on `print` instead, or grouping the two, reproduces the bug verbatim. All three spellings were confirmed to fail the guard, and the shipped shape to pass it. `overrides_with` has no public getter in clap 4.6 and is not covered.
- **The `--public-key is required with --print` bail now says why** a supplied credential cannot stand in. The key-embedding writes (`registry deploy`, `market create`, `proxy-oracle create`, `gov create`, `redstone create`) reach `public_key()` during argument evaluation, before the plan branch, so they would otherwise say nothing about the key sitting in the operator's environment.
- **No credential value reaches a log.** `ignored_credential_warning` reads only whether a credential is present. CodeQL caught the assertion guarding against a leaked key printing the string that failed it; the obvious de-taint (`if is_none() { return None }`) trips `clippy::question_mark`, which asks for exactly the `as_ref()?` CodeQL taints, so the mode is computed before gating on presence.
- **Tests**: the two negative parse cases inverted to positive ones; the warning cases collapsed into one `rstest` table covering print, keychain, and executed writes; `with_cleared_credential_env` dropped from the five `--print` parse tests that no longer need it.

## Verification

| check | result |
|---|---|
| `SECRET_KEY=… <write> --signer-id … --print json` | parses, warns, plan on stdout, exit 0 |
| explicit `--secret-key` with `--print` | parses; stderr says the credential is ignored |
| `--sign-with` with `--print` | still a parse error |
| `just test-fast -p templar-manager` | 386 passed |
| `cargo fmt --all --check`, `clippy -D warnings` | clean |

Each acceptance criterion was confirmed against the built binary, not only in tests.

## Follow-up

`--sign-with` cannot name the in-process backend, so the default is selected implicitly by `--secret-key`'s presence. Adding a `secret-key` variant guarded by `required_if_eq` closes that gap; filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017LjSJpeQ4MZ3vrzXRSoyvE

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/626)
<!-- Reviewable:end -->

