### PR TITLE
feat(manager): let --sign-with name the in-process backend (ENG-712)

### DIFF
--- a/tools/manager/src/commands/market/create.rs
+++ b/tools/manager/src/commands/market/create.rs
@@ -5,7 +5,7 @@ use templar_common::market::MarketConfiguration;
 use templar_gateway_methods_spec::market as spec;
 
 use crate::commands::deploy_common::DeployTargetArgs;
-use crate::commands::signer::SignerArgs;
+use crate::commands::signer::{Authorization, SignerArgs};
 
 /// Deploy a market from a registered version, granting the signer a full access
 /// key so the operator retains control of the new account.
@@ -27,7 +27,7 @@ struct MarketInitArgs {
 }
 
 impl Create {
-    pub fn try_into_spec(self) -> anyhow::Result<spec::Create> {
+    pub fn try_into_spec(self, authorization: &Authorization) -> anyhow::Result<spec::Create> {
         let file = std::fs::File::open(&self.init_args_file).with_context(|| {
             format!(
                 "open market init args from {}",
@@ -37,9 +37,8 @@ impl Create {
         let init_args: MarketInitArgs =
             serde_json::from_reader(file).context("parse market init args")?;
 
-        let signer = self.signer;
         Ok(spec::Create {
-            target: self.target.resolve(|| signer.public_key())?,
+            target: self.target.resolve(|| authorization.public_key())?,
             configuration: init_args.configuration,
         })
     }

--- a/tools/manager/src/commands/proxy_oracle/create.rs
+++ b/tools/manager/src/commands/proxy_oracle/create.rs
@@ -3,7 +3,7 @@ use near_account_id::AccountId;
 use templar_gateway_methods_spec::proxy_oracle as spec;
 
 use crate::commands::deploy_common::DeployTargetArgs;
-use crate::commands::signer::SignerArgs;
+use crate::commands::signer::{Authorization, SignerArgs};
 
 /// Deploy a proxy oracle from a registered version, granting the signer a full
 /// access key so the operator retains control of the new account.
@@ -23,10 +23,9 @@ pub struct Create {
 }
 
 impl Create {
-    pub fn try_into_spec(self) -> anyhow::Result<spec::Create> {
-        let signer = self.signer;
+    pub fn try_into_spec(self, authorization: &Authorization) -> anyhow::Result<spec::Create> {
         Ok(spec::Create {
-            target: self.target.resolve(|| signer.public_key())?,
+            target: self.target.resolve(|| authorization.public_key())?,
             owner_id: self.owner_id,
         })
     }

--- a/tools/manager/src/commands/proxy_oracle/governance/create.rs
+++ b/tools/manager/src/commands/proxy_oracle/governance/create.rs
@@ -10,7 +10,7 @@ use templar_proxy_oracle_near_governance_common::GovernancePolicy;
 use crate::commands::deploy_common::DeployTargetArgs;
 use crate::commands::duration::parse_duration;
 use crate::commands::load_json_file;
-use crate::commands::signer::SignerArgs;
+use crate::commands::signer::{Authorization, SignerArgs};
 
 /// Create (deploy-from-registry) a governance contract, building its
 /// `new(proxy_oracle_id, admin_id, policy)` init args from typed flags.
@@ -41,7 +41,7 @@ pub struct GovernanceCreate {
 }
 
 impl GovernanceCreate {
-    pub fn try_into_spec(self) -> anyhow::Result<spec::Create> {
+    pub fn try_into_spec(self, authorization: &Authorization) -> anyhow::Result<spec::Create> {
         let policy: GovernancePolicy = match self.policy_file {
             Some(path) => load_json_file(&path).context("parse GovernancePolicy")?,
             None => {
@@ -49,9 +49,8 @@ impl GovernanceCreate {
             }
         };
 
-        let signer = self.signer;
         Ok(spec::Create {
-            target: self.target.resolve(|| signer.public_key())?,
+            target: self.target.resolve(|| authorization.public_key())?,
             proxy_oracle_id: self.proxy_oracle_id,
             admin_id: self.admin_id,
             policy,

--- a/tools/manager/src/commands/proxy_oracle/preflight.rs
+++ b/tools/manager/src/commands/proxy_oracle/preflight.rs
@@ -1,6 +1,7 @@
 use clap::{ArgGroup, Args};
 use near_account_id::AccountId;
 
+use crate::commands::signer::Mode;
 use crate::resolve::OracleTarget;
 
 /// Read-only pre-upgrade checks over a deployed proxy oracle's stored state.
@@ -44,9 +45,9 @@ pub struct PreflightArgs {
 }
 
 impl PreflightArgs {
-    /// Whether the preflight should run at all. `print` builds a payload without submitting, so it
+    /// Whether the preflight should run at all. A plan builds a payload without submitting, so it
     /// stays offline.
-    pub(crate) fn runs(&self, printing: bool) -> bool {
-        !self.skip_preflight && !printing
+    pub(crate) fn runs(&self, mode: &Mode) -> bool {
+        !self.skip_preflight && !matches!(mode, Mode::Plan(_))
     }
 }

--- a/tools/manager/src/commands/redstone/create.rs
+++ b/tools/manager/src/commands/redstone/create.rs
@@ -8,7 +8,7 @@ use templar_gateway_methods_spec::redstone as spec;
 
 use crate::commands::deploy_common::DeployTargetArgs;
 use crate::commands::load_json_file;
-use crate::commands::signer::SignerArgs;
+use crate::commands::signer::{Authorization, SignerArgs};
 
 #[derive(Clone, Copy, Debug, ValueEnum)]
 enum Preset {
@@ -46,7 +46,7 @@ pub struct Create {
 }
 
 impl Create {
-    pub fn try_into_spec(self) -> anyhow::Result<spec::Create> {
+    pub fn try_into_spec(self, authorization: &Authorization) -> anyhow::Result<spec::Create> {
         let config: Config = match self.preset {
             Some(Preset::Prod) => config::prod(),
             Some(Preset::Test) => config::test(),
@@ -59,9 +59,8 @@ impl Create {
             }
         };
 
-        let signer = self.signer;
         Ok(spec::Create {
-            target: self.target.resolve(|| signer.public_key())?,
+            target: self.target.resolve(|| authorization.public_key())?,
             config,
             admin_id: self.admin_id,
         })

--- a/tools/manager/src/commands/registry/deploy.rs
+++ b/tools/manager/src/commands/registry/deploy.rs
@@ -3,7 +3,7 @@ use clap::{ArgGroup, Args};
 use templar_gateway_methods_spec::registry as spec;
 
 use crate::commands::deploy_common::DeployTargetArgs;
-use crate::commands::signer::SignerArgs;
+use crate::commands::signer::{Authorization, SignerArgs};
 
 /// Deploy an already-registered contract version to a new account, granting full
 /// access keys (the signer's by default) so the operator retains control.
@@ -32,7 +32,7 @@ pub struct Deploy {
 }
 
 impl Deploy {
-    pub fn try_into_spec(self) -> anyhow::Result<spec::Deploy> {
+    pub fn try_into_spec(self, authorization: &Authorization) -> anyhow::Result<spec::Deploy> {
         // clap's required, mutually-exclusive `init` group guarantees exactly one
         // source is present.
         let init_bytes = match (self.init_args, self.init_args_file) {
@@ -45,9 +45,8 @@ impl Deploy {
                 .with_context(|| format!("read init args from {}", path.display()))?,
             (None, None) => unreachable!("clap requires one of --init-args / --init-args-file"),
         };
-        let signer = self.signer;
         Ok(spec::Deploy {
-            target: self.target.resolve(|| signer.public_key())?,
+            target: self.target.resolve(|| authorization.public_key())?,
             init_args: templar_gateway_types::Base64Bytes(init_bytes),
         })
     }

--- a/tools/manager/src/commands/signer.rs
+++ b/tools/manager/src/commands/signer.rs
@@ -54,7 +54,7 @@ impl fmt::Debug for Mode {
 
 /// The account authorizing a write and how the write is signed, resolved once
 /// from [`SignerArgs`] per invocation.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug)]
 pub(crate) struct Authorization {
     account_id: ManagedAccountId,
     /// The key the operator asserted via `--public-key`, unvalidated: only a
@@ -162,11 +162,19 @@ impl TryFrom<&SignerArgs> for Authorization {
         if let Some(warning) = args.ignored_credential_warning(&mode) {
             tracing::warn!("{warning}");
         }
-        Ok(Self {
+        let authorization = Self {
             account_id: args.account_id(),
             asserted_public_key: args.public_key,
             mode,
-        })
+        };
+        if let Mode::InProcess(secret) = &authorization.mode {
+            ensure_asserted_key_is_held(
+                &authorization.account_id,
+                authorization.asserted_public_key,
+                secret.public_key(),
+            )?;
+        }
+        Ok(authorization)
     }
 }
 
@@ -184,32 +192,21 @@ impl Authorization {
     /// creates. Only the in-process backend derives it locally; the others
     /// need `--public-key`.
     pub(crate) fn public_key(&self) -> anyhow::Result<PublicKey> {
-        let asserted = self.asserted_public_key.map(PublicKey::from);
         let required_with = match &self.mode {
-            Mode::InProcess(secret) => {
-                let derived = PublicKey::from(secret.public_key());
-                // A contradicting --public-key is an error, not an override.
-                if let Some(supplied) = asserted {
-                    anyhow::ensure!(
-                        supplied == derived,
-                        "--public-key names a different key than --secret-key signs with. \
-                         The new account would grant full access to a key you do not hold; \
-                         drop --public-key to use the signer's own."
-                    );
-                }
-                return Ok(derived);
-            }
+            Mode::InProcess(secret) => return Ok(PublicKey::from(secret.public_key())),
             Mode::Plan(_) => {
                 "--print for writes that embed the signer's key. \
                  --secret-key/$SECRET_KEY cannot stand in: a plan is signed by whoever executes it"
             }
             Mode::Keychain => "--sign-with for writes that embed the signer's key",
         };
-        asserted.ok_or_else(|| anyhow::anyhow!("--public-key is required with {required_with}"))
+        self.asserted_public_key
+            .map(PublicKey::from)
+            .ok_or_else(|| anyhow::anyhow!("--public-key is required with {required_with}"))
     }
 
     /// The signing account's key as a gateway nonce lane, and the key that lane
-    /// will sign with — checked against `--public-key` when one was asserted.
+    /// will sign with.
     ///
     /// Async because the keychain backend discovers the account's keys on chain
     /// before matching them against the OS keystore.
@@ -217,13 +214,18 @@ impl Authorization {
         self,
         network: &NetworkConfig,
     ) -> anyhow::Result<(PooledSigner, CliPublicKey)> {
-        let signer = match self.mode {
+        let Self {
+            account_id,
+            asserted_public_key,
+            mode,
+        } = self;
+        let signer = match mode {
             Mode::Plan(_) => anyhow::bail!("--print is not supported for this orchestrated write"),
             Mode::InProcess(secret) => {
                 Signer::from_secret_key(*secret).context("build a signer from --secret-key")?
             }
             Mode::Keychain => {
-                Signer::from_keystore_with_search_for_keys(self.account_id.0.clone(), network)
+                Signer::from_keystore_with_search_for_keys(account_id.0.clone(), network)
                     .await
                     .context("find a usable key for this account in the OS keychain")?
             }
@@ -233,29 +235,38 @@ impl Authorization {
             .get_public_key()
             .await
             .context("ask the signing backend which key it will sign with")?;
-
-        // A deploy embeds this key as the full access key on the account it
-        // creates, and an external backend cannot validate it before resolving.
-        if let Some(asserted) = self.asserted_public_key {
-            anyhow::ensure!(
-                asserted == public_key,
-                "--public-key is `{asserted}`, but `{}` will sign with \
-                 `{public_key}`. A deploy embeds `--public-key` as the full access \
-                 key on the account it creates, so this would hand control to a \
-                 key you do not hold. Drop --public-key to use the signing key, \
-                 or pass the one the backend holds.",
-                *self.account_id,
-            );
-        }
+        // An external backend can only be checked once it says which key it holds.
+        ensure_asserted_key_is_held(&account_id, asserted_public_key, public_key)?;
 
         // Both backends produce a single-key signer: `Signer::new` seeds its
         // pool with one entry, the keychain's first matching key.
-        let pooled = PooledSigner::from_signer(self.account_id, signer)
+        let pooled = PooledSigner::from_signer(account_id, signer)
             .await
             .context("register the signing key as a gateway nonce lane")?;
 
         Ok((pooled, public_key))
     }
+}
+
+/// A deploy embeds `--public-key` as the full access key on the account it
+/// creates, so an asserted key the signer does not hold hands the account to
+/// someone else.
+fn ensure_asserted_key_is_held(
+    account_id: &ManagedAccountId,
+    asserted: Option<CliPublicKey>,
+    held: CliPublicKey,
+) -> anyhow::Result<()> {
+    if let Some(asserted) = asserted {
+        anyhow::ensure!(
+            asserted == held,
+            "--public-key is `{asserted}`, but `{}` will sign with `{held}`. \
+             A deploy embeds `--public-key` as the full access key on the account \
+             it creates, so this would hand control to a key you do not hold. \
+             Drop --public-key to use the signing key, or pass the one the backend holds.",
+            **account_id,
+        );
+    }
+    Ok(())
 }
 
 /// A secret key with no bound account — for teardown flows (e.g. `registry
@@ -557,10 +568,10 @@ mod tests {
         assert_eq!(*pooled.account_id(), signer.account_id());
     }
 
-    /// The resolved key, not the operator's assertion, is what a deploy embeds
-    /// as the new account's full access key.
-    #[tokio::test]
-    async fn resolve_rejects_an_asserted_key_the_backend_does_not_hold() {
+    /// The signing key, not the operator's assertion, is what a deploy embeds
+    /// as the new account's full access key. Caught before any work is done.
+    #[test]
+    fn an_asserted_key_the_signer_does_not_hold_is_rejected() {
         let signer = SignerArgs {
             public_key: Some(
                 "ed25519:5TMKtTtD5uuMF28ovo7vVge7oAu58eXjySJWTrwcEB5w"
@@ -571,10 +582,6 @@ mod tests {
         };
 
         let error = Authorization::try_from(&signer)
-            .expect("in-process resolves from the credential")
-            .resolve(&offline_network())
-            .await
-            .map(|_| ())
             .expect_err("a key the signer does not hold must not be embedded")
             .to_string();
 

--- a/tools/manager/src/commands/signer.rs
+++ b/tools/manager/src/commands/signer.rs
@@ -23,15 +23,44 @@ pub(crate) enum PrintFormat {
     Sputnik,
 }
 
-/// A backend that holds the signing key *outside* this process.
-///
-/// The in-process path is deliberately not a variant: naming it would let
-/// `--sign-with secret-key` satisfy clap's "a backend was chosen" while
-/// supplying no key.
+/// Where the signing key lives.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
 pub(crate) enum SigningBackend {
+    /// The key passed as `--secret-key`/`$SECRET_KEY`, held in this process.
+    SecretKey,
     /// The OS keychain, looked up by account id.
     Keychain,
+}
+
+/// How a write is signed: planned for someone else, or here by a named backend.
+///
+/// `Debug` is hand-written to redact the key; do not derive it.
+#[derive(PartialEq, Eq)]
+pub(crate) enum Mode {
+    Plan(PrintFormat),
+    InProcess(Box<SecretKey>),
+    Keychain,
+}
+
+impl fmt::Debug for Mode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Plan(format) => f.debug_tuple("Plan").field(format).finish(),
+            Self::InProcess(_) => f.debug_tuple("InProcess").field(&REDACTED).finish(),
+            Self::Keychain => f.write_str("Keychain"),
+        }
+    }
+}
+
+/// The account authorizing a write and how the write is signed, resolved once
+/// from [`SignerArgs`] per invocation.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct Authorization {
+    account_id: ManagedAccountId,
+    /// The key the operator asserted via `--public-key`, unvalidated: only a
+    /// resolved signer can check it, so the caller that resolves must.
+    asserted_public_key: Option<CliPublicKey>,
+    mode: Mode,
 }
 
 /// The account authorizing a write and either its execution credential or its
@@ -43,14 +72,13 @@ pub struct SignerArgs {
     /// Account that signs the transaction, or the DAO account that will execute a plan.
     #[arg(long, env = "SIGNER_ID", value_name = "ACCOUNT_ID")]
     signer_id: AccountId,
-    /// Hold the signing key outside this process. Omit to use `--secret-key`.
+    /// Backend that signs the transaction. Defaults to `secret-key`.
     #[arg(long, value_enum, value_name = "BACKEND", conflicts_with = "print")]
     sign_with: Option<SigningBackend>,
     /// Private key for `--signer-id`, in `ed25519:…` form.
     ///
-    /// Required only for the default `secret-key` backend: naming any
-    /// `--sign-with` backend lifts the requirement, and `--print` needs no
-    /// credential at all.
+    /// Required by the `secret-key` backend, named or defaulted; other backends
+    /// and `--print` need no credential.
     ///
     /// Held as text and parsed on use. Clap validates an env value during
     /// parsing whatever else was passed, and `SECRET_KEY` is a name other tools
@@ -61,9 +89,8 @@ pub struct SignerArgs {
         env = "SECRET_KEY",
         hide_env_values = true,
         value_name = "SECRET_KEY",
-        // `--sign-with` names only external backends, so its presence always
-        // means some other credential source was chosen.
         required_unless_present_any = ["print", "sign_with"],
+        required_if_eq("sign_with", "secret-key"),
     )]
     secret_key: Option<String>,
     /// Plan the write without executing it, then print the selected representation.
@@ -94,25 +121,12 @@ impl SignerArgs {
         ManagedAccountId::from(self.signer_id.clone())
     }
 
-    /// The key the operator *asserted* via `--public-key`, unvalidated: only a
-    /// resolved signer can check it, so the caller that resolves must.
-    pub const fn asserted_public_key(&self) -> Option<CliPublicKey> {
-        self.public_key
-    }
-
-    /// The requested plan-only output format.
-    pub const fn print(&self) -> Option<PrintFormat> {
-        self.print
-    }
-
-    /// The warning for a credential the selected mode will not use.
-    pub(crate) fn ignored_credential_warning(&self) -> Option<String> {
-        let mode = match (self.print, self.sign_with) {
-            (Some(_), _) => "--print only plans the write, so nothing is signed",
-            (None, Some(SigningBackend::Keychain)) => {
-                "--sign-with keychain signs with the key the keychain holds"
-            }
-            (None, None) => return None,
+    /// The warning for a credential `mode` will not use.
+    fn ignored_credential_warning(&self, mode: &Mode) -> Option<String> {
+        let mode = match mode {
+            Mode::Plan(_) => "--print only plans the write, so nothing is signed",
+            Mode::Keychain => "--sign-with keychain signs with the key the keychain holds",
+            Mode::InProcess(_) => return None,
         };
         // Presence only: nothing derived from the key itself may reach a log.
         self.secret_key.is_some().then(|| {
@@ -123,65 +137,93 @@ impl SignerArgs {
         })
     }
 
-    /// The signer's public key, granted full access on accounts a deploy
-    /// creates. Only the in-process backend derives it locally.
-    pub fn public_key(&self) -> anyhow::Result<PublicKey> {
-        // The in-process backend derives from the key it will actually sign
-        // with. Returning a supplied `--public-key` here would grant a full
-        // access key on the new account to a key the signer does not hold,
-        // while the transaction is signed by the secret — so a contradicting
-        // value is an error, not an override.
-        if self.sign_with.is_none() && self.print.is_none() {
-            let derived = PublicKey::from(self.secret()?.public_key());
-            if let Some(supplied) = &self.public_key {
-                anyhow::ensure!(
-                    PublicKey::from(*supplied) == derived,
-                    "--public-key names a different key than --secret-key signs with. \
-                     The new account would grant full access to a key you do not hold; \
-                     drop --public-key to use the signer's own."
-                );
-            }
-            return Ok(derived);
-        }
+    /// The source text never reaches the error.
+    fn secret(&self) -> anyhow::Result<SecretKey> {
+        self.secret_key
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("missing --secret-key"))?
+            .parse()
+            .map_err(|_| anyhow::anyhow!("--secret-key/$SECRET_KEY is not a valid `ed25519:…` key"))
+    }
+}
 
-        if let Some(public_key) = &self.public_key {
-            return Ok(PublicKey::from(*public_key));
+impl TryFrom<&SignerArgs> for Authorization {
+    type Error = anyhow::Error;
+
+    /// The one place plan mode and the backend are decided; warns here, once,
+    /// about a credential the chosen mode will not use.
+    fn try_from(args: &SignerArgs) -> anyhow::Result<Self> {
+        let backend = args.sign_with.unwrap_or(SigningBackend::SecretKey);
+        let mode = match (args.print, backend) {
+            (Some(format), _) => Mode::Plan(format),
+            (None, SigningBackend::SecretKey) => Mode::InProcess(Box::new(args.secret()?)),
+            (None, SigningBackend::Keychain) => Mode::Keychain,
+        };
+        if let Some(warning) = args.ignored_credential_warning(&mode) {
+            tracing::warn!("{warning}");
         }
-        if self.print.is_some() {
-            anyhow::bail!(
-                "--public-key is required with --print for writes that embed the signer's key. \
-                 --secret-key/$SECRET_KEY cannot stand in: a plan is signed by whoever executes it."
-            );
-        }
-        if self.sign_with.is_some() {
-            anyhow::bail!(
-                "--public-key is required with --sign-with for writes that embed the signer's key"
-            );
-        }
-        Ok(PublicKey::from(self.secret()?.public_key()))
+        Ok(Self {
+            account_id: args.account_id(),
+            asserted_public_key: args.public_key,
+            mode,
+        })
+    }
+}
+
+impl Authorization {
+    /// The signing account.
+    pub(crate) const fn account_id(&self) -> &ManagedAccountId {
+        &self.account_id
+    }
+
+    pub(crate) const fn mode(&self) -> &Mode {
+        &self.mode
+    }
+
+    /// The signer's public key, granted full access on accounts a deploy
+    /// creates. Only the in-process backend derives it locally; the others
+    /// need `--public-key`.
+    pub(crate) fn public_key(&self) -> anyhow::Result<PublicKey> {
+        let asserted = self.asserted_public_key.map(PublicKey::from);
+        let required_with = match &self.mode {
+            Mode::InProcess(secret) => {
+                let derived = PublicKey::from(secret.public_key());
+                // A contradicting --public-key is an error, not an override.
+                if let Some(supplied) = asserted {
+                    anyhow::ensure!(
+                        supplied == derived,
+                        "--public-key names a different key than --secret-key signs with. \
+                         The new account would grant full access to a key you do not hold; \
+                         drop --public-key to use the signer's own."
+                    );
+                }
+                return Ok(derived);
+            }
+            Mode::Plan(_) => {
+                "--print for writes that embed the signer's key. \
+                 --secret-key/$SECRET_KEY cannot stand in: a plan is signed by whoever executes it"
+            }
+            Mode::Keychain => "--sign-with for writes that embed the signer's key",
+        };
+        asserted.ok_or_else(|| anyhow::anyhow!("--public-key is required with {required_with}"))
     }
 
     /// The signing account's key as a gateway nonce lane, and the key that lane
-    /// will sign with.
+    /// will sign with — checked against `--public-key` when one was asserted.
     ///
     /// Async because the keychain backend discovers the account's keys on chain
     /// before matching them against the OS keystore.
-    pub async fn resolve(
-        &self,
+    pub(crate) async fn resolve(
+        self,
         network: &NetworkConfig,
     ) -> anyhow::Result<(PooledSigner, CliPublicKey)> {
-        if self.print.is_some() {
-            anyhow::bail!("--print is not supported for this orchestrated write");
-        }
-        if let Some(warning) = self.ignored_credential_warning() {
-            tracing::warn!("{warning}");
-        }
-
-        let signer = match self.sign_with {
-            None => Signer::from_secret_key(self.secret()?.clone())
-                .context("build a signer from --secret-key")?,
-            Some(SigningBackend::Keychain) => {
-                Signer::from_keystore_with_search_for_keys(self.signer_id.clone(), network)
+        let signer = match self.mode {
+            Mode::Plan(_) => anyhow::bail!("--print is not supported for this orchestrated write"),
+            Mode::InProcess(secret) => {
+                Signer::from_secret_key(*secret).context("build a signer from --secret-key")?
+            }
+            Mode::Keychain => {
+                Signer::from_keystore_with_search_for_keys(self.account_id.0.clone(), network)
                     .await
                     .context("find a usable key for this account in the OS keychain")?
             }
@@ -192,25 +234,27 @@ impl SignerArgs {
             .await
             .context("ask the signing backend which key it will sign with")?;
 
+        // A deploy embeds this key as the full access key on the account it
+        // creates, and an external backend cannot validate it before resolving.
+        if let Some(asserted) = self.asserted_public_key {
+            anyhow::ensure!(
+                asserted == public_key,
+                "--public-key is `{asserted}`, but `{}` will sign with \
+                 `{public_key}`. A deploy embeds `--public-key` as the full access \
+                 key on the account it creates, so this would hand control to a \
+                 key you do not hold. Drop --public-key to use the signing key, \
+                 or pass the one the backend holds.",
+                *self.account_id,
+            );
+        }
+
         // Both backends produce a single-key signer: `Signer::new` seeds its
         // pool with one entry, the keychain's first matching key.
-        let pooled = PooledSigner::from_signer(self.account_id(), signer)
+        let pooled = PooledSigner::from_signer(self.account_id, signer)
             .await
             .context("register the signing key as a gateway nonce lane")?;
 
         Ok((pooled, public_key))
-    }
-
-    /// Both callers reject print mode before reaching here, so this only has to
-    /// account for a credential that clap left absent.
-    ///
-    /// The source text never reaches the error.
-    fn secret(&self) -> anyhow::Result<SecretKey> {
-        self.secret_key
-            .as_ref()
-            .ok_or_else(|| anyhow::anyhow!("missing --secret-key"))?
-            .parse()
-            .map_err(|_| anyhow::anyhow!("--secret-key/$SECRET_KEY is not a valid `ed25519:…` key"))
     }
 }
 
@@ -280,7 +324,7 @@ mod tests {
 
     const SECRET: &str = "ed25519:2vVTQWpoZvYZBS4HYFZtzU2rxpoQSrhyFWdaHLqSdyaEfgjefbSKiFpuVatuRqax3HFvVq2tkkqWH2h7tso2nK8q";
 
-    #[derive(Parser)]
+    #[derive(Parser, Debug)]
     struct Harness {
         #[command(flatten)]
         signer: SignerArgs,
@@ -290,6 +334,23 @@ mod tests {
     /// this only satisfies the signature.
     fn offline_network() -> NetworkConfig {
         NetworkConfigBuilder::new(Network::Testnet).build()
+    }
+
+    /// Built rather than parsed: an ambient `SECRET_KEY` would otherwise decide
+    /// the outcome of the cases that supply none.
+    fn signer_args(
+        signer_id: &str,
+        sign_with: Option<SigningBackend>,
+        secret_key: Option<&str>,
+        print: Option<PrintFormat>,
+    ) -> SignerArgs {
+        SignerArgs {
+            signer_id: signer_id.parse().expect("valid account"),
+            sign_with,
+            secret_key: secret_key.map(str::to_owned),
+            print,
+            public_key: None,
+        }
     }
 
     #[test]
@@ -318,6 +379,20 @@ mod tests {
         );
     }
 
+    #[test]
+    fn authorization_debug_redacts_secret_key() {
+        let signer = signer_args("signer.testnet", None, Some(SECRET), None);
+        let rendered = format!("{:?}", Authorization::try_from(&signer).expect("resolves"));
+        assert!(
+            !rendered.contains(SECRET),
+            "secret leaked in Debug: {rendered}"
+        );
+        assert!(
+            rendered.contains(REDACTED),
+            "no redaction marker: {rendered}"
+        );
+    }
+
     /// `SECRET_KEY` is a name other tools use. Parsing it eagerly meant an
     /// unrelated ambient value failed every write, including the ones that never
     /// read it.
@@ -334,6 +409,13 @@ mod tests {
         ])
         .expect("the keychain backend never reads the secret");
 
+        assert_eq!(
+            Authorization::try_from(&harness.signer)
+                .expect("the keychain backend must not parse the unused credential")
+                .mode(),
+            &Mode::Keychain
+        );
+
         let error = harness
             .signer
             .secret()
@@ -349,29 +431,29 @@ mod tests {
 
     /// Print mode wins over `--sign-with`, so accepting both silently ignored
     /// the backend the operator named.
-    #[test]
-    fn a_backend_cannot_be_named_alongside_print() {
-        assert!(
-            Harness::try_parse_from([
-                "tmplrmgr",
-                "--signer-id",
-                "signer.testnet",
-                "--sign-with",
-                "keychain",
-                "--print",
-                "json",
-            ])
-            .is_err(),
-            "print mode signs nothing, so a backend is a contradiction"
-        );
+    #[rstest::rstest]
+    #[case::keychain("keychain")]
+    #[case::secret_key("secret-key")]
+    fn a_backend_cannot_be_named_alongside_print(#[case] backend: &str) {
+        let error = Harness::try_parse_from([
+            "tmplrmgr",
+            "--signer-id",
+            "signer.testnet",
+            "--sign-with",
+            backend,
+            "--print",
+            "json",
+        ])
+        .expect_err("print mode signs nothing, so a backend is a contradiction");
+
+        assert_eq!(error.kind(), ErrorKind::ArgumentConflict);
     }
 
-    /// Built rather than parsed: an ambient `SECRET_KEY` would otherwise decide
-    /// the outcome of the cases that supply none.
     #[rstest::rstest]
     #[case::plan_ignores_it(Some(PrintFormat::Json), None, Some(SECRET), true)]
     #[case::keychain_ignores_it(None, Some(SigningBackend::Keychain), Some(SECRET), true)]
     #[case::a_signed_write_uses_it(None, None, Some(SECRET), false)]
+    #[case::the_named_default_uses_it(None, Some(SigningBackend::SecretKey), Some(SECRET), false)]
     #[case::a_plan_without_one(Some(PrintFormat::Json), None, None, false)]
     fn warns_only_for_a_credential_the_mode_will_not_use(
         #[case] print: Option<PrintFormat>,
@@ -379,15 +461,10 @@ mod tests {
         #[case] secret_key: Option<&str>,
         #[case] warns: bool,
     ) {
-        let signer = SignerArgs {
-            signer_id: "signer.testnet".parse().expect("valid account"),
-            sign_with,
-            secret_key: secret_key.map(str::to_owned),
-            print,
-            public_key: None,
-        };
+        let signer = signer_args("signer.testnet", sign_with, secret_key, print);
+        let authorization = Authorization::try_from(&signer).expect("resolves");
 
-        let Some(warning) = signer.ignored_credential_warning() else {
+        let Some(warning) = signer.ignored_credential_warning(authorization.mode()) else {
             assert!(!warns, "an unused credential must not pass silently");
             return;
         };
@@ -401,18 +478,25 @@ mod tests {
         );
     }
 
+    #[test]
+    fn the_in_process_backend_needs_a_parseable_key() {
+        let signer = signer_args("signer.testnet", None, Some("not-a-near-key"), None);
+
+        let error = Authorization::try_from(&signer)
+            .expect_err("an in-process write cannot sign with an unusable key")
+            .to_string();
+
+        assert!(error.contains("not a valid"), "{error}");
+        assert!(!error.contains("not-a-near-key"), "{error}");
+    }
+
     #[tokio::test]
     async fn plan_mode_rejects_credential_resolution() {
-        let signer = SignerArgs {
-            signer_id: "dao.near".parse().expect("valid account"),
-            sign_with: None,
-            secret_key: None,
-            print: Some(PrintFormat::Sputnik),
-            public_key: None,
-        };
+        let signer = signer_args("dao.near", None, None, Some(PrintFormat::Sputnik));
 
         assert_eq!(
-            signer
+            Authorization::try_from(&signer)
+                .expect("a plan resolves without a credential")
                 .resolve(&offline_network())
                 .await
                 // `Signer` is not `Debug`, so discard the Ok value before asserting.
@@ -425,34 +509,76 @@ mod tests {
 
     #[test]
     fn plan_write_that_embeds_a_key_requires_public_key() {
-        let signer = SignerArgs {
-            signer_id: "dao.near".parse().expect("valid account"),
-            sign_with: None,
-            secret_key: None,
-            print: Some(PrintFormat::Json),
-            public_key: None,
-        };
+        let signer = signer_args("dao.near", None, None, Some(PrintFormat::Json));
 
-        assert!(signer
+        assert!(Authorization::try_from(&signer)
+            .expect("a plan resolves without a credential")
             .public_key()
             .expect_err("plan must not invent a public key")
             .to_string()
             .contains("--public-key"));
     }
 
-    #[test]
-    fn execution_public_key_is_derived_from_typed_secret() {
+    /// Naming the default backend must change nothing about how the key is
+    /// derived.
+    #[rstest::rstest]
+    #[case::defaulted(None)]
+    #[case::named(Some(SigningBackend::SecretKey))]
+    fn execution_public_key_is_derived_from_typed_secret(
+        #[case] sign_with: Option<SigningBackend>,
+    ) {
         let secret_key: SecretKey = SECRET.parse().expect("valid secret");
         let expected = PublicKey::from(secret_key.public_key());
+        let signer = signer_args("signer.testnet", sign_with, Some(SECRET), None);
+
+        let derived = Authorization::try_from(&signer)
+            .expect("in-process resolves from the credential")
+            .public_key()
+            .expect("derived public key");
+        assert_eq!(derived, expected);
+    }
+
+    /// Naming the default backend must change nothing about which key signs.
+    #[rstest::rstest]
+    #[case::defaulted(None)]
+    #[case::named(Some(SigningBackend::SecretKey))]
+    #[tokio::test]
+    async fn execution_signs_with_the_typed_secret(#[case] sign_with: Option<SigningBackend>) {
+        let secret_key: SecretKey = SECRET.parse().expect("valid secret");
+        let signer = signer_args("signer.testnet", sign_with, Some(SECRET), None);
+
+        let (pooled, public_key) = Authorization::try_from(&signer)
+            .expect("in-process resolves from the credential")
+            .resolve(&offline_network())
+            .await
+            .expect("the in-process backend resolves offline");
+
+        assert_eq!(public_key, secret_key.public_key());
+        assert_eq!(*pooled.account_id(), signer.account_id());
+    }
+
+    /// The resolved key, not the operator's assertion, is what a deploy embeds
+    /// as the new account's full access key.
+    #[tokio::test]
+    async fn resolve_rejects_an_asserted_key_the_backend_does_not_hold() {
         let signer = SignerArgs {
-            signer_id: "signer.testnet".parse().expect("valid account"),
-            sign_with: None,
-            secret_key: Some(SECRET.to_owned()),
-            print: None,
-            public_key: None,
+            public_key: Some(
+                "ed25519:5TMKtTtD5uuMF28ovo7vVge7oAu58eXjySJWTrwcEB5w"
+                    .parse()
+                    .expect("valid public key"),
+            ),
+            ..signer_args("signer.testnet", None, Some(SECRET), None)
         };
 
-        assert_eq!(signer.public_key().expect("derived public key"), expected);
+        let error = Authorization::try_from(&signer)
+            .expect("in-process resolves from the credential")
+            .resolve(&offline_network())
+            .await
+            .map(|_| ())
+            .expect_err("a key the signer does not hold must not be embedded")
+            .to_string();
+
+        assert!(error.contains("a key you do not hold"), "{error}");
     }
 
     /// The point of the flag: an operator can sign without a key in the
@@ -475,15 +601,10 @@ mod tests {
     /// so writes that embed the signer's key must be told what it is.
     #[test]
     fn external_backend_requires_an_explicit_public_key() {
-        let signer = SignerArgs {
-            signer_id: "signer.testnet".parse().expect("valid account"),
-            sign_with: Some(SigningBackend::Keychain),
-            secret_key: None,
-            print: None,
-            public_key: None,
-        };
+        let signer = signer_args("signer.testnet", Some(SigningBackend::Keychain), None, None);
 
-        assert!(signer
+        assert!(Authorization::try_from(&signer)
+            .expect("the keychain backend resolves without a credential")
             .public_key()
             .expect_err("a device key cannot be derived locally")
             .to_string()

--- a/tools/manager/src/commands/signer.rs
+++ b/tools/manager/src/commands/signer.rs
@@ -394,14 +394,10 @@ mod tests {
     fn authorization_debug_redacts_secret_key() {
         let signer = signer_args("signer.testnet", None, Some(SECRET), None);
         let rendered = format!("{:?}", Authorization::try_from(&signer).expect("resolves"));
-        assert!(
-            !rendered.contains(SECRET),
-            "secret leaked in Debug: {rendered}"
-        );
-        assert!(
-            rendered.contains(REDACTED),
-            "no redaction marker: {rendered}"
-        );
+        // The rendering is deliberately kept out of the messages: on failure it
+        // would be the leaked secret.
+        assert!(!rendered.contains(SECRET), "secret leaked in Debug");
+        assert!(rendered.contains(REDACTED), "no redaction marker");
     }
 
     /// `SECRET_KEY` is a name other tools use. Parsing it eagerly meant an

--- a/tools/manager/src/context.rs
+++ b/tools/manager/src/context.rs
@@ -25,7 +25,7 @@ use templar_gateway_types::{
 };
 
 use crate::cli::Cli;
-use crate::commands::signer::{PrintFormat, SignerArgs};
+use crate::commands::signer::{Authorization, Mode, PrintFormat, SignerArgs};
 
 pub(crate) struct CliContext {
     /// An unsigned client for reads and ordinary write plans. Executed writes
@@ -88,7 +88,9 @@ impl CliContext {
         &self,
         signer: &SignerArgs,
     ) -> anyhow::Result<(ManagedAccountId, Client)> {
-        let (account_id, client, _) = self.signing_client_and_key(signer).await?;
+        let (account_id, client, _) = self
+            .signing_client_and_key(Authorization::try_from(signer)?)
+            .await?;
         Ok((account_id, client))
     }
 
@@ -96,25 +98,10 @@ impl CliContext {
     /// resolving twice can prompt twice and yield two different keys.
     pub(crate) async fn signing_client_and_key(
         &self,
-        signer: &SignerArgs,
+        authorization: Authorization,
     ) -> anyhow::Result<(ManagedAccountId, Client, near_api::PublicKey)> {
-        let (signing, public_key) = signer.resolve(&self.network).await?;
+        let (signing, public_key) = authorization.resolve(&self.network).await?;
         let account_id = signing.account_id().clone();
-
-        // A deploy embeds this key as the full access key on the account it
-        // creates, and an external backend cannot validate it before resolving.
-        if let Some(asserted) = signer.asserted_public_key() {
-            anyhow::ensure!(
-                asserted == public_key,
-                "--public-key is `{asserted}`, but `{}` will sign with \
-                 `{public_key}`. A deploy embeds `--public-key` as the full access \
-                 key on the account it creates, so this would hand control to a \
-                 key you do not hold. Drop --public-key to use the signing key, \
-                 or pass the one the backend holds.",
-                *signer.account_id(),
-            );
-        }
-
         let client = Client::builder(self.network.clone())
             .with_signer(signing)
             .build()
@@ -139,14 +126,41 @@ impl CliContext {
         S: MethodSpec<Output = WriteOperationResult>,
         Dispatch: PlanWrite<S, GatewayContext>,
     {
-        if let Some(format) = signer.print() {
-            if let Some(warning) = signer.ignored_credential_warning() {
-                tracing::warn!("{warning}");
-            }
+        self.write_with(signer, |_| Ok(body)).await
+    }
+
+    /// [`Self::write`] for a spec that embeds the signer's public key: the
+    /// authorization is resolved before the spec is built, then signs it.
+    pub(crate) async fn write_with<S>(
+        &self,
+        signer: SignerArgs,
+        into_spec: impl FnOnce(&Authorization) -> anyhow::Result<S>,
+    ) -> anyhow::Result<()>
+    where
+        S: MethodSpec<Output = WriteOperationResult>,
+        Dispatch: PlanWrite<S, GatewayContext>,
+    {
+        let authorization = Authorization::try_from(&signer)?;
+        let body = into_spec(&authorization)?;
+        self.write_authorized(authorization, body).await
+    }
+
+    /// [`Self::write`] for a caller that already resolved the authorization,
+    /// to gate a preflight on it.
+    pub(crate) async fn write_authorized<S>(
+        &self,
+        authorization: Authorization,
+        body: S,
+    ) -> anyhow::Result<()>
+    where
+        S: MethodSpec<Output = WriteOperationResult>,
+        Dispatch: PlanWrite<S, GatewayContext>,
+    {
+        if let Mode::Plan(format) = *authorization.mode() {
             let plan = self
                 .client
                 .plan_request(WriteRequest {
-                    signer_account_id: signer.account_id(),
+                    signer_account_id: authorization.account_id().clone(),
                     idempotency_key: None,
                     body,
                 })
@@ -154,7 +168,7 @@ impl CliContext {
             return print_plan(format, plan);
         }
 
-        let (account_id, client) = self.signing_client_for(&signer).await?;
+        let (account_id, client, _) = self.signing_client_and_key(authorization).await?;
         let output = client.execute_as(account_id, body).await?;
         self.finish_write(&output)
     }
@@ -172,10 +186,8 @@ impl CliContext {
         Ctx: Clone,
         OracleUpdatesDispatch: PlanWrite<S, Ctx>,
     {
-        if let Some(format) = signer.print() {
-            if let Some(warning) = signer.ignored_credential_warning() {
-                tracing::warn!("{warning}");
-            }
+        let authorization = Authorization::try_from(&signer)?;
+        if let Mode::Plan(format) = *authorization.mode() {
             let context = layer_sources(GatewayContext::new(self.network.clone())?)?;
             let plan = <OracleUpdatesDispatch as PlanWrite<S, Ctx>>::plan(
                 WriteRequest {
@@ -189,7 +201,7 @@ impl CliContext {
             return print_plan(format, plan);
         }
 
-        let (signing, _) = signer.resolve(&self.network).await?;
+        let (signing, _) = authorization.resolve(&self.network).await?;
         let account_id = signing.account_id().clone();
         let (base_context, driver, signer_account_ids) = Client::builder(self.network.clone())
             .with_signer(signing)

--- a/tools/manager/src/context.rs
+++ b/tools/manager/src/context.rs
@@ -145,8 +145,7 @@ impl CliContext {
         self.write_authorized(authorization, body).await
     }
 
-    /// [`Self::write`] for a caller that already resolved the authorization,
-    /// to gate a preflight on it.
+    /// [`Self::write`] for a caller that already resolved the authorization.
     pub(crate) async fn write_authorized<S>(
         &self,
         authorization: Authorization,
@@ -191,7 +190,7 @@ impl CliContext {
             let context = layer_sources(GatewayContext::new(self.network.clone())?)?;
             let plan = <OracleUpdatesDispatch as PlanWrite<S, Ctx>>::plan(
                 WriteRequest {
-                    signer_account_id: signer.account_id(),
+                    signer_account_id: authorization.account_id().clone(),
                     idempotency_key: None,
                     body,
                 },

--- a/tools/manager/src/dispatch/mod.rs
+++ b/tools/manager/src/dispatch/mod.rs
@@ -33,13 +33,13 @@ use crate::commands::{
     pyth::PythNs,
     redstone::RedstoneNs,
     registry::RegistryNs,
+    signer::Authorization,
     spec::SpecNs,
     storage::StorageNs,
 };
 use crate::context::{
     all_sources, lazer_source, print_json, pyth_source, redstone_source, CliContext,
 };
-
 /// A kernel price as a plain number.
 ///
 /// Shared by the aggregation dry-run and the reference cross-check, which
@@ -108,7 +108,10 @@ async fn registry(ctx: CliContext, ns: RegistryNs) -> anyhow::Result<()> {
         RegistryNs::ListDeploymentsByKind(a) => ctx.read(a.into_spec()).await,
         RegistryNs::GetDeployment(a) => ctx.read(a.into_spec()).await,
         RegistryNs::AddVersion(a) => ctx.write(a.signer.clone(), a.try_into_spec()?).await,
-        RegistryNs::Deploy(a) => ctx.write(a.signer.clone(), a.try_into_spec()?).await,
+        RegistryNs::Deploy(a) => {
+            ctx.write_with(a.signer.clone(), |auth| a.try_into_spec(auth))
+                .await
+        }
         RegistryNs::RemoveVersion(a) => teardown::remove_version(ctx, a).await,
         RegistryNs::Remove(a) => teardown::registry_remove(ctx, a).await,
         RegistryNs::ClearDeployments(a) => teardown::clear_deployments(ctx, a).await,
@@ -135,7 +138,10 @@ async fn ft(ctx: CliContext, ns: FtNs) -> anyhow::Result<()> {
 
 async fn market(ctx: CliContext, ns: MarketNs) -> anyhow::Result<()> {
     match ns {
-        MarketNs::Create(a) => ctx.write(a.signer.clone(), a.try_into_spec()?).await,
+        MarketNs::Create(a) => {
+            ctx.write_with(a.signer.clone(), |auth| a.try_into_spec(auth))
+                .await
+        }
         MarketNs::Export(a) => export::market(ctx, a).await,
         MarketNs::Plan(a) => plan::plan(ctx, a).await,
         MarketNs::Apply(a) => plan::apply(ctx, a).await,
@@ -158,7 +164,10 @@ struct Removed {
 
 async fn proxy_oracle(ctx: CliContext, ns: ProxyOracleNs) -> anyhow::Result<()> {
     match ns {
-        ProxyOracleNs::Create(a) => ctx.write(a.signer.clone(), a.try_into_spec()?).await,
+        ProxyOracleNs::Create(a) => {
+            ctx.write_with(a.signer.clone(), |auth| a.try_into_spec(auth))
+                .await
+        }
         ProxyOracleNs::GetProxy(a) => {
             let oracle_id = a.target.resolve(&ctx).await?;
             ctx.read(a.into_spec(oracle_id)).await
@@ -181,11 +190,12 @@ async fn proxy_oracle(ctx: CliContext, ns: ProxyOracleNs) -> anyhow::Result<()> 
             ctx.write(a.signer.clone(), a.into_spec(oracle_id)).await
         }
         ProxyOracleNs::Upgrade(a) => {
+            let authorization = Authorization::try_from(&a.signer)?;
             let oracle_id = a.target.resolve(&ctx).await?;
-            if a.preflight.runs(a.signer.print().is_some()) {
+            if a.preflight.runs(authorization.mode()) {
                 upgrade_preflight::gate(&ctx, &oracle_id, &a.preflight.skip_check).await?;
             }
-            ctx.write(a.signer.clone(), a.try_into_spec(oracle_id)?)
+            ctx.write_authorized(authorization, a.try_into_spec(oracle_id)?)
                 .await
         }
         ProxyOracleNs::Governance(a) => proxy_oracle_governance(ctx, a).await,
@@ -251,7 +261,10 @@ async fn proxy_oracle_governance(
     use templar_gateway_methods_spec::proxy_oracle_governance as gov;
 
     match ns {
-        ProxyOracleGovernanceNs::Create(a) => ctx.write(a.signer.clone(), a.try_into_spec()?).await,
+        ProxyOracleGovernanceNs::Create(a) => {
+            ctx.write_with(a.signer.clone(), |auth| a.try_into_spec(auth))
+                .await
+        }
         ProxyOracleGovernanceNs::CreateProposal(a) => proposals::create(ctx, a).await,
         ProxyOracleGovernanceNs::CancelProposal(a) => {
             let governance_id = a.proposal.target.resolve(&ctx).await?;
@@ -299,7 +312,10 @@ async fn proxy_oracle_governance(
 
 async fn redstone(ctx: CliContext, ns: RedstoneNs) -> anyhow::Result<()> {
     match ns {
-        RedstoneNs::Create(a) => ctx.write(a.signer.clone(), a.try_into_spec()?).await,
+        RedstoneNs::Create(a) => {
+            ctx.write_with(a.signer.clone(), |auth| a.try_into_spec(auth))
+                .await
+        }
         RedstoneNs::GetConfig(a) => ctx.read(a.into_spec()).await,
         RedstoneNs::ReadPriceData(a) => ctx.read(a.into_spec()).await,
         RedstoneNs::ListRole(a) => ctx.read(a.into_spec()).await,

--- a/tools/manager/src/dispatch/mod.rs
+++ b/tools/manager/src/dispatch/mod.rs
@@ -40,6 +40,7 @@ use crate::commands::{
 use crate::context::{
     all_sources, lazer_source, print_json, pyth_source, redstone_source, CliContext,
 };
+
 /// A kernel price as a plain number.
 ///
 /// Shared by the aggregation dry-run and the reference cross-check, which

--- a/tools/manager/src/dispatch/patch.rs
+++ b/tools/manager/src/dispatch/patch.rs
@@ -93,14 +93,13 @@ pub(super) async fn apply(ctx: CliContext, args: Apply) -> anyhow::Result<()> {
         plan.schema
     );
     ensure_patch_has_operations(&plan)?;
+    let authorization = Authorization::try_from(&args.signer)?;
     anyhow::ensure!(
-        args.signer.account_id().0 == plan.signer_id,
+        authorization.account_id().0 == plan.signer_id,
         "patch plan expects signer `{}`, but apply uses `{}`",
         plan.signer_id,
-        args.signer.account_id().0,
+        authorization.account_id().0,
     );
-
-    let authorization = Authorization::try_from(&args.signer)?;
     let public_key = authorization.public_key()?;
     anyhow::ensure!(
         public_key == templar_gateway_types::primitive::PublicKey::from(plan.public_key),

--- a/tools/manager/src/dispatch/patch.rs
+++ b/tools/manager/src/dispatch/patch.rs
@@ -19,6 +19,7 @@ use crate::{
     commands::{
         patch::{Apply, Plan},
         registry::STORAGE_AMOUNT_PER_BYTE,
+        signer::Authorization,
     },
     context::CliContext,
     dispatch::patch_state::{fetch_complete_state, RawStateEntry, StateSnapshot},
@@ -99,7 +100,8 @@ pub(super) async fn apply(ctx: CliContext, args: Apply) -> anyhow::Result<()> {
         args.signer.account_id().0,
     );
 
-    let public_key = args.signer.public_key()?;
+    let authorization = Authorization::try_from(&args.signer)?;
+    let public_key = authorization.public_key()?;
     anyhow::ensure!(
         public_key == templar_gateway_types::primitive::PublicKey::from(plan.public_key),
         "patch plan was reviewed for a different signing public key"
@@ -143,7 +145,7 @@ pub(super) async fn apply(ctx: CliContext, args: Apply) -> anyhow::Result<()> {
         "patch was not sent",
     )?;
     reporter.digest();
-    ctx.write(args.signer, plan.batch).await
+    ctx.write_authorized(authorization, plan.batch).await
 }
 
 fn ensure_patch_signer(

--- a/tools/manager/src/dispatch/plan.rs
+++ b/tools/manager/src/dispatch/plan.rs
@@ -26,6 +26,7 @@ use templar_proxy_oracle_near_common::input::Source;
 use templar_proxy_oracle_near_governance_common::{GovernancePolicy, Operation};
 
 use crate::commands::market::{Apply, Plan};
+use crate::commands::signer::Authorization;
 use crate::context::{print_json, CliContext};
 use crate::report::Reporter;
 use crate::spec::journal::{self, Journal};
@@ -211,7 +212,9 @@ pub(super) async fn apply(ctx: CliContext, args: Apply) -> anyhow::Result<()> {
     // Resolved once, here, and carried through to the send: the keychain
     // backend discovers keys on chain and may prompt, and a second resolution
     // could hand back a different key than the one checked below.
-    let (signer, client, signing_key) = ctx.signing_client_and_key(&args.signer).await?;
+    let (signer, client, signing_key) = ctx
+        .signing_client_and_key(Authorization::try_from(&args.signer)?)
+        .await?;
 
     // Asked of the backend, not of `--public-key`: checking a grant against
     // the operator's own assertion checks nothing.

--- a/tools/manager/src/dispatch/proposals.rs
+++ b/tools/manager/src/dispatch/proposals.rs
@@ -11,6 +11,7 @@ use templar_gateway_methods_spec::proxy_oracle_governance as gov;
 use templar_gateway_types::{common::WriteOperationResult, ManagedAccountId};
 
 use crate::commands::proxy_oracle::{CreateProposal, ExecuteProposalArgs};
+use crate::commands::signer::{Authorization, Mode};
 use crate::context::{print_json, CliContext};
 
 /// Plan or create a governance proposal. Resolves the proposal id (fetching the
@@ -21,15 +22,14 @@ use crate::context::{print_json, CliContext};
 /// proposal's TTL to elapse before executing it.
 pub(super) async fn create(ctx: CliContext, mut args: CreateProposal) -> anyhow::Result<()> {
     let execute_when_ready = args.execute_when_ready();
-    let signer_args = args.signer.clone();
+    let authorization = Authorization::try_from(&args.signer)?;
     let preflight = args.preflight.clone();
     let requires_upgrade_preflight = args.requires_upgrade_preflight();
     let governance_id = args.target.resolve(&ctx).await?;
 
     // An upgrade proposal is gated before it is even queued, so a deployment that cannot survive
     // the new code is caught while the fix is still cheap.
-    let preflight_runs =
-        requires_upgrade_preflight && preflight.runs(signer_args.print().is_some());
+    let preflight_runs = requires_upgrade_preflight && preflight.runs(authorization.mode());
     if preflight_runs {
         super::upgrade_preflight::gate_governed_oracle(&ctx, &governance_id, &preflight).await?;
     }
@@ -57,11 +57,11 @@ pub(super) async fn create(ctx: CliContext, mut args: CreateProposal) -> anyhow:
     };
 
     let create_spec = args.try_into_spec(governance_id.clone(), id)?;
-    if signer_args.print().is_some() {
-        return ctx.write(signer_args, create_spec).await;
+    if let Mode::Plan(_) = authorization.mode() {
+        return ctx.write_authorized(authorization, create_spec).await;
     }
 
-    let (signer, client) = ctx.signing_client_for(&signer_args).await?;
+    let (signer, client, _) = ctx.signing_client_and_key(authorization).await?;
     let create = client.execute_as(signer.clone(), create_spec).await?;
     // Fail fast if the create reverted, before waiting on / executing a proposal
     // that was never created.
@@ -94,11 +94,12 @@ pub(super) async fn create(ctx: CliContext, mut args: CreateProposal) -> anyhow:
 /// waits for its TTL to elapse, so an early call blocks instead of failing on
 /// an immature proposal.
 pub(super) async fn execute(ctx: CliContext, args: ExecuteProposalArgs) -> anyhow::Result<()> {
+    let authorization = Authorization::try_from(&args.signer)?;
     let governance_id = args.target.resolve(&ctx).await?;
     if args.when_ready() {
         wait_for_maturity(&ctx, &governance_id, args.id()).await?;
     }
-    if args.preflight.runs(args.signer.print().is_some()) {
+    if args.preflight.runs(authorization.mode()) {
         super::upgrade_preflight::gate_queued_upgrade(
             &ctx,
             &governance_id,
@@ -107,7 +108,7 @@ pub(super) async fn execute(ctx: CliContext, args: ExecuteProposalArgs) -> anyho
         )
         .await?;
     }
-    ctx.write(args.signer.clone(), args.into_spec(governance_id))
+    ctx.write_authorized(authorization, args.into_spec(governance_id))
         .await
 }
 

--- a/tools/manager/src/tests.rs
+++ b/tools/manager/src/tests.rs
@@ -1,10 +1,10 @@
 use std::sync::Mutex;
 
-use clap::{CommandFactory, Parser};
+use clap::{error::ErrorKind, CommandFactory, Parser};
 
 use super::cli::{Cli, Command};
 use super::commands::proxy_oracle::{CreateProposal, ProxyOracleGovernanceNs, ProxyOracleNs};
-use super::commands::signer::PrintFormat;
+use super::commands::signer::{Authorization, Mode, PrintFormat, SignerArgs};
 
 static ENV_LOCK: Mutex<()> = Mutex::new(());
 
@@ -132,6 +132,23 @@ const CREDS: [&str; 4] = [
     TEST_SECRET_KEY,
 ];
 
+/// The authorization the parsed credentials select; a parse test's inputs
+/// are valid by construction.
+fn authorized(signer: &SignerArgs) -> Authorization {
+    Authorization::try_from(signer).expect("parsed credentials resolve")
+}
+
+/// Clap's metadata for one of `write`'s flags, by field id.
+fn write_arg(id: &str) -> clap::Arg {
+    Cli::command()
+        .find_subcommand("write")
+        .expect("write is a subcommand")
+        .get_arguments()
+        .find(|arg| arg.get_id() == id)
+        .unwrap_or_else(|| panic!("write has no `{id}` flag"))
+        .clone()
+}
+
 fn try_parse_write<'a>(args: impl IntoIterator<Item = &'a str>) -> Result<Cli, clap::Error> {
     Cli::try_parse_from(
         [
@@ -186,7 +203,7 @@ fn parses_write_fallback_with_json() {
         super::cli::Command::Write(call) => {
             assert_eq!(call.call.method, "registry.removeVersion");
             assert!(call.call.json.is_some());
-            call.signer
+            authorized(&call.signer)
                 .public_key()
                 .expect("credentials should resolve");
         }
@@ -201,17 +218,8 @@ fn parses_write_fallback_with_json() {
 /// whenever the developer's environment happens to set `PYTH_LAZER_API_KEY`.
 #[test]
 fn write_fallback_does_not_require_a_lazer_key() {
-    let write = Cli::command()
-        .find_subcommand("write")
-        .expect("write is a subcommand")
-        .clone();
-    let api_key = write
-        .get_arguments()
-        .find(|arg| arg.get_id() == "pyth_lazer_api_key")
-        .expect("write flattens the oracle source flags");
-
     assert!(
-        !api_key.is_required_set(),
+        !write_arg("pyth_lazer_api_key").is_required_set(),
         "--pyth-lazer-api-key must not be required by `write`"
     );
 }
@@ -262,42 +270,82 @@ fn no_argument_pairs_an_env_source_with_a_conflict() {
     walk(&Cli::command(), "tmplrmgr");
 }
 
-#[test]
-fn write_requires_secret_key_or_print() {
-    // Omitting both execution credentials and plan mode is a parse error, so no
-    // build or network work is reachable.
-    let result = with_cleared_credential_env(|| try_parse_write(["--signer-id", "dao.near"]));
-    let error = result.expect_err("a write needs --secret-key or --print");
+fn in_process() -> Mode {
+    Mode::InProcess(Box::new(TEST_SECRET_KEY.parse().expect("valid secret")))
+}
+
+/// Every way a write can be authorized, by flags and by an ambient `SECRET_KEY`.
+/// The environment is set explicitly per row: an ambient value would otherwise
+/// decide the rows that supply none.
+#[rstest::rstest]
+#[case::nothing(&[], None, Err(ErrorKind::MissingRequiredArgument))]
+#[case::the_default_backend_named_without_a_key(
+    &["--sign-with", "secret-key"], None, Err(ErrorKind::MissingRequiredArgument)
+)]
+#[case::secret_key_flag(&["--secret-key", TEST_SECRET_KEY], None, Ok(in_process()))]
+#[case::secret_key_env(&[], Some(TEST_SECRET_KEY), Ok(in_process()))]
+#[case::the_default_backend_named_with_a_flag(
+    &["--sign-with", "secret-key", "--secret-key", TEST_SECRET_KEY], None, Ok(in_process())
+)]
+#[case::the_default_backend_named_with_env(
+    &["--sign-with", "secret-key"], Some(TEST_SECRET_KEY), Ok(in_process())
+)]
+#[case::print_alone(&["--print", "json"], None, Ok(Mode::Plan(PrintFormat::Json)))]
+#[case::print_with_an_unused_flag(
+    &["--print", "sputnik", "--secret-key", TEST_SECRET_KEY], None, Ok(Mode::Plan(PrintFormat::Sputnik))
+)]
+// ENG-692: an ambient `SECRET_KEY` is extremely common and must not block a plan.
+#[case::print_with_an_unused_env(
+    &["--print", "json"], Some(TEST_SECRET_KEY), Ok(Mode::Plan(PrintFormat::Json))
+)]
+#[case::keychain_alone(&["--sign-with", "keychain"], None, Ok(Mode::Keychain))]
+#[case::keychain_with_an_unused_env(
+    &["--sign-with", "keychain"], Some(TEST_SECRET_KEY), Ok(Mode::Keychain)
+)]
+#[case::keychain_with_print(
+    &["--sign-with", "keychain", "--print", "json"], None, Err(ErrorKind::ArgumentConflict)
+)]
+#[case::the_default_backend_with_print(
+    &["--sign-with", "secret-key", "--print", "json"], None, Err(ErrorKind::ArgumentConflict)
+)]
+fn write_authorization_matrix(
+    #[case] flags: &[&str],
+    #[case] ambient_secret: Option<&str>,
+    #[case] expected: Result<Mode, ErrorKind>,
+) {
+    let result = with_credential_env(ambient_secret, || {
+        try_parse_write(
+            ["--signer-id", "dao.near"]
+                .into_iter()
+                .chain(flags.iter().copied()),
+        )
+    });
+
+    let actual = result.map(|cli| {
+        let Command::Write(call) = cli.command else {
+            panic!("expected Write variant");
+        };
+        authorized(&call.signer)
+    });
     assert_eq!(
-        error.kind(),
-        clap::error::ErrorKind::MissingRequiredArgument
+        actual
+            .as_ref()
+            .map(Authorization::mode)
+            .map_err(clap::Error::kind),
+        expected.as_ref().map_err(|kind| *kind),
+        "{actual:?}"
     );
 }
 
-/// The whole point of `--sign-with`: naming a backend that holds the key
-/// elsewhere must satisfy the credential requirement with nothing in the
-/// environment. Credentials are cleared so an ambient `SECRET_KEY` cannot make
-/// this pass for the wrong reason.
 #[test]
-fn write_with_an_external_backend_needs_no_secret_key() {
-    let result = with_cleared_credential_env(|| {
-        try_parse_write(["--signer-id", "dao.near", "--sign-with", "keychain"])
-    });
+fn help_lists_every_signing_backend() {
+    let backends = write_arg("sign_with")
+        .get_possible_values()
+        .iter()
+        .map(|value| value.get_name().to_owned())
+        .collect::<Vec<_>>();
 
-    result.expect("--sign-with keychain should satisfy the credential requirement");
-}
-
-/// `--sign-with` names only external backends. `secret-key` is not one, so it
-/// cannot be typed — an invocation that would parse while supplying no
-/// credential is unrepresentable rather than merely discouraged.
-#[test]
-fn sign_with_cannot_name_the_in_process_backend() {
-    let error = with_cleared_credential_env(|| {
-        try_parse_write(["--signer-id", "dao.near", "--sign-with", "secret-key"])
-    })
-    .expect_err("`secret-key` is not a --sign-with backend");
-
-    assert_eq!(error.kind(), clap::error::ErrorKind::InvalidValue);
+    assert_eq!(backends, ["secret-key", "keychain"]);
 }
 
 /// A supplied `--public-key` must never become the full access key on a new
@@ -305,7 +353,7 @@ fn sign_with_cannot_name_the_in_process_backend() {
 /// of the account to a key the operator does not have.
 #[test]
 fn public_key_cannot_override_the_signing_key() {
-    let cli = with_cleared_credential_env(|| {
+    let cli = with_credential_env(None, || {
         try_parse_write([
             "--signer-id",
             "signer.testnet",
@@ -320,8 +368,7 @@ fn public_key_cannot_override_the_signing_key() {
     let Command::Write(call) = cli.command else {
         panic!("expected Write variant")
     };
-    let error = call
-        .signer
+    let error = authorized(&call.signer)
         .public_key()
         .expect_err("a contradicting --public-key must not be honored");
 
@@ -331,75 +378,9 @@ fn public_key_cannot_override_the_signing_key() {
     );
 }
 
-/// An ambient `SECRET_KEY` is extremely common. It must not break the documented
-/// `--sign-with keychain --public-key …` flow, whose backend ignores it.
-#[test]
-fn an_ambient_secret_does_not_block_an_external_backend() {
-    let _guard = ENV_LOCK.lock().expect("env lock should not be poisoned");
-    let original = std::env::var_os("SECRET_KEY");
-    std::env::set_var("SECRET_KEY", TEST_SECRET_KEY);
-
-    let result = try_parse_write([
-        "--signer-id",
-        "dao.near",
-        "--sign-with",
-        "keychain",
-        "--public-key",
-        "ed25519:5TMKtTtD5uuMF28ovo7vVge7oAu58eXjySJWTrwcEB5w",
-    ]);
-
-    restore_env("SECRET_KEY", original);
-    result.expect("an ignored ambient secret must not fail parsing");
-}
-
-#[test]
-fn write_command_accepts_print_without_secret() {
-    let result = with_cleared_credential_env(|| {
-        try_parse_write(["--signer-id", "dao.near", "--print", "sputnik"])
-    });
-    let cli = result.expect("plan-only write should parse without a secret");
-    let Command::Write(call) = cli.command else {
-        panic!("expected Write variant");
-    };
-    assert_eq!(call.signer.print(), Some(PrintFormat::Sputnik));
-}
-
-#[test]
-fn print_accepts_an_explicit_secret_key() {
-    let cli = try_parse_write([
-        "--signer-id",
-        "dao.near",
-        "--print",
-        "json",
-        "--secret-key",
-        TEST_SECRET_KEY,
-    ])
-    .expect("plan-only write should accept an unused credential");
-
-    let Command::Write(call) = cli.command else {
-        panic!("expected Write variant");
-    };
-    assert_eq!(call.signer.print(), Some(PrintFormat::Json));
-}
-
-#[test]
-fn print_accepts_a_secret_key_from_environment() {
-    let _guard = ENV_LOCK.lock().expect("env lock should not be poisoned");
-    let original_secret = std::env::var_os("SECRET_KEY");
-    std::env::set_var("SECRET_KEY", TEST_SECRET_KEY);
-    let result = try_parse_write(["--signer-id", "dao.near", "--print", "json"]);
-    restore_env("SECRET_KEY", original_secret);
-
-    let cli = result.expect("an ambient secret must not block a plan-only write");
-    let Command::Write(call) = cli.command else {
-        panic!("expected Write variant");
-    };
-    assert_eq!(call.signer.print(), Some(PrintFormat::Json));
-}
-
 #[test]
 fn public_key_is_not_a_credential() {
-    let error = with_cleared_credential_env(|| {
+    let error = with_credential_env(None, || {
         try_parse_write([
             "--signer-id",
             "signer.testnet",
@@ -409,10 +390,7 @@ fn public_key_is_not_a_credential() {
     })
     .expect_err("--public-key names a key, it does not authorize a write");
 
-    assert_eq!(
-        error.kind(),
-        clap::error::ErrorKind::MissingRequiredArgument
-    );
+    assert_eq!(error.kind(), ErrorKind::MissingRequiredArgument);
     assert!(
         error.to_string().contains("--secret-key"),
         "the error should name the missing credential: {error}"
@@ -433,7 +411,7 @@ fn read_command_rejects_credentials() {
     ])
     .expect_err("credentials on a read should fail to parse");
 
-    assert_eq!(error.kind(), clap::error::ErrorKind::UnknownArgument);
+    assert_eq!(error.kind(), ErrorKind::UnknownArgument);
 }
 
 /// Deliberately not a parse error. Clap validates an env value whatever else was
@@ -464,7 +442,9 @@ fn signer_env_satisfies_write_credentials() {
         let cli = try_parse_write([]).map_err(|error| anyhow::anyhow!(error.to_string()))?;
 
         match cli.command {
-            super::cli::Command::Write(call) => call.signer.public_key().map(|_| ()),
+            super::cli::Command::Write(call) => Authorization::try_from(&call.signer)?
+                .public_key()
+                .map(|_| ()),
             _ => anyhow::bail!("expected Write variant"),
         }
     })();
@@ -475,14 +455,17 @@ fn signer_env_satisfies_write_credentials() {
     result.expect("env-provided credentials should satisfy a write command");
 }
 
-/// Run `f` with ambient signer credentials cleared and environment mutation
-/// serialized, then restore the original values.
-fn with_cleared_credential_env<T>(f: impl FnOnce() -> T) -> T {
+/// Run `f` with `SIGNER_ID` cleared and `SECRET_KEY` set to exactly `secret`,
+/// environment mutation serialized, then restore the original values.
+fn with_credential_env<T>(secret: Option<&str>, f: impl FnOnce() -> T) -> T {
     let _guard = ENV_LOCK.lock().expect("env lock should not be poisoned");
     let original_signer = std::env::var_os("SIGNER_ID");
     let original_secret = std::env::var_os("SECRET_KEY");
     std::env::remove_var("SIGNER_ID");
-    std::env::remove_var("SECRET_KEY");
+    match secret {
+        Some(secret) => std::env::set_var("SECRET_KEY", secret),
+        None => std::env::remove_var("SECRET_KEY"),
+    }
     let result = f();
     restore_env("SIGNER_ID", original_signer);
     restore_env("SECRET_KEY", original_secret);
@@ -501,8 +484,5 @@ fn read_fallback_rejects_missing_json() {
     let error = Cli::try_parse_from(["tmplrmgr", "read", "account.get"])
         .expect_err("read fallback should require --json or --json-file");
 
-    assert_eq!(
-        error.kind(),
-        clap::error::ErrorKind::MissingRequiredArgument
-    );
+    assert_eq!(error.kind(), ErrorKind::MissingRequiredArgument);
 }

--- a/tools/manager/src/tests.rs
+++ b/tools/manager/src/tests.rs
@@ -1,3 +1,4 @@
+use std::ffi::OsString;
 use std::sync::Mutex;
 
 use clap::{error::ErrorKind, CommandFactory, Parser};
@@ -313,7 +314,7 @@ fn write_authorization_matrix(
     #[case] ambient_secret: Option<&str>,
     #[case] expected: Result<Mode, ErrorKind>,
 ) {
-    let result = with_credential_env(ambient_secret, || {
+    let result = with_credential_env(None, ambient_secret, || {
         try_parse_write(
             ["--signer-id", "dao.near"]
                 .into_iter()
@@ -348,39 +349,9 @@ fn help_lists_every_signing_backend() {
     assert_eq!(backends, ["secret-key", "keychain"]);
 }
 
-/// A supplied `--public-key` must never become the full access key on a new
-/// account when the signer holds a different secret — that would hand control
-/// of the account to a key the operator does not have.
-#[test]
-fn public_key_cannot_override_the_signing_key() {
-    let cli = with_credential_env(None, || {
-        try_parse_write([
-            "--signer-id",
-            "signer.testnet",
-            "--secret-key",
-            TEST_SECRET_KEY,
-            "--public-key",
-            "ed25519:5TMKtTtD5uuMF28ovo7vVge7oAu58eXjySJWTrwcEB5w",
-        ])
-    })
-    .expect("clap accepts the pair; the conflict is semantic");
-
-    let Command::Write(call) = cli.command else {
-        panic!("expected Write variant")
-    };
-    let error = authorized(&call.signer)
-        .public_key()
-        .expect_err("a contradicting --public-key must not be honored");
-
-    assert!(
-        error.to_string().contains("a key you do not hold"),
-        "error should say why: {error}"
-    );
-}
-
 #[test]
 fn public_key_is_not_a_credential() {
-    let error = with_credential_env(None, || {
+    let error = with_credential_env(None, None, || {
         try_parse_write([
             "--signer-id",
             "signer.testnet",
@@ -428,52 +399,44 @@ fn an_invalid_secret_key_is_not_a_parse_error() {
     assert!(!rendered.contains(secret), "secret leaked: {rendered}");
 }
 
+/// Scripted/CI usage relies on `SIGNER_ID`/`SECRET_KEY` env sourcing satisfying
+/// the structural credentials with no explicit flags.
 #[test]
 fn signer_env_satisfies_write_credentials() {
-    // Scripted/CI usage relies on SIGNER_ID/SECRET_KEY env sourcing satisfying the
-    // structural credentials with no explicit flags.
-    let _guard = ENV_LOCK.lock().expect("env lock should not be poisoned");
-    let original_signer = std::env::var_os("SIGNER_ID");
-    let original_secret = std::env::var_os("SECRET_KEY");
-    std::env::set_var("SIGNER_ID", "signer.testnet");
-    std::env::set_var("SECRET_KEY", TEST_SECRET_KEY);
+    let cli = with_credential_env(Some("signer.testnet"), Some(TEST_SECRET_KEY), || {
+        try_parse_write([])
+    })
+    .expect("env-provided credentials should satisfy a write command");
 
-    let result = (|| {
-        let cli = try_parse_write([]).map_err(|error| anyhow::anyhow!(error.to_string()))?;
-
-        match cli.command {
-            super::cli::Command::Write(call) => Authorization::try_from(&call.signer)?
-                .public_key()
-                .map(|_| ()),
-            _ => anyhow::bail!("expected Write variant"),
-        }
-    })();
-
-    restore_env("SIGNER_ID", original_signer);
-    restore_env("SECRET_KEY", original_secret);
-
-    result.expect("env-provided credentials should satisfy a write command");
+    let Command::Write(call) = cli.command else {
+        panic!("expected Write variant");
+    };
+    authorized(&call.signer)
+        .public_key()
+        .expect("credentials should resolve");
 }
 
-/// Run `f` with `SIGNER_ID` cleared and `SECRET_KEY` set to exactly `secret`,
-/// environment mutation serialized, then restore the original values.
-fn with_credential_env<T>(secret: Option<&str>, f: impl FnOnce() -> T) -> T {
+/// Run `f` with `SIGNER_ID` and `SECRET_KEY` set to exactly the given values
+/// (cleared when `None`), environment mutation serialized, then restore the
+/// original values.
+fn with_credential_env<T>(
+    signer_id: Option<&str>,
+    secret: Option<&str>,
+    f: impl FnOnce() -> T,
+) -> T {
     let _guard = ENV_LOCK.lock().expect("env lock should not be poisoned");
     let original_signer = std::env::var_os("SIGNER_ID");
     let original_secret = std::env::var_os("SECRET_KEY");
-    std::env::remove_var("SIGNER_ID");
-    match secret {
-        Some(secret) => std::env::set_var("SECRET_KEY", secret),
-        None => std::env::remove_var("SECRET_KEY"),
-    }
+    set_env("SIGNER_ID", signer_id.map(OsString::from));
+    set_env("SECRET_KEY", secret.map(OsString::from));
     let result = f();
-    restore_env("SIGNER_ID", original_signer);
-    restore_env("SECRET_KEY", original_secret);
+    set_env("SIGNER_ID", original_signer);
+    set_env("SECRET_KEY", original_secret);
     result
 }
 
-fn restore_env(key: &str, original: Option<std::ffi::OsString>) {
-    match original {
+fn set_env(key: &str, value: Option<OsString>) {
+    match value {
         Some(value) => std::env::set_var(key, value),
         None => std::env::remove_var(key),
     }

--- a/tools/manager/src/tests/deploy_script.rs
+++ b/tools/manager/src/tests/deploy_script.rs
@@ -6,7 +6,7 @@ use crate::commands::owner::OwnerNs;
 use crate::commands::proxy_oracle::ProxyOracleGovernanceNs;
 use crate::commands::registry::RegistryNs;
 
-use super::{parse_create_proposal, parse_governance, try_parse_governance, CREDS};
+use super::{authorized, parse_create_proposal, parse_governance, try_parse_governance, CREDS};
 
 const COLLATERAL_PRICE_ID: &str =
     "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc";
@@ -92,9 +92,11 @@ fn registry_deploy_rejects_invalid_inline_init_args() {
     match cli.command {
         Command::Registry {
             command: RegistryNs::Deploy(cmd),
-        } => cmd
-            .try_into_spec()
-            .expect_err("invalid inline JSON should be rejected"),
+        } => {
+            let authorization = authorized(&cmd.signer);
+            cmd.try_into_spec(&authorization)
+                .expect_err("invalid inline JSON should be rejected")
+        }
         _ => panic!("expected Registry::Deploy"),
     };
 }
@@ -125,7 +127,11 @@ fn registry_deploy_accepts_explicit_inline_null_init_args() {
     let params = match cli.command {
         Command::Registry {
             command: RegistryNs::Deploy(cmd),
-        } => cmd.try_into_spec().expect("deploy should build"),
+        } => {
+            let authorization = authorized(&cmd.signer);
+            cmd.try_into_spec(&authorization)
+                .expect("deploy should build")
+        }
         _ => panic!("expected Registry::Deploy"),
     };
 
@@ -169,7 +175,11 @@ fn registry_deploy_reads_init_args_file() {
     let params = match cli.command {
         Command::Registry {
             command: RegistryNs::Deploy(cmd),
-        } => cmd.try_into_spec().expect("deploy should build"),
+        } => {
+            let authorization = authorized(&cmd.signer);
+            cmd.try_into_spec(&authorization)
+                .expect("deploy should build")
+        }
         _ => panic!("expected Registry::Deploy"),
     };
 

--- a/tools/manager/src/tests/market.rs
+++ b/tools/manager/src/tests/market.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 use serde_json::json;
 
-use super::CREDS;
+use super::{authorized, CREDS};
 use crate::cli::{Cli, Command};
 use crate::commands::market::MarketNs;
 
@@ -34,9 +34,11 @@ fn parses_market_create_typed_args() {
     let params = match cli.command {
         Command::Market {
             command: MarketNs::Create(cmd),
-        } => cmd
-            .try_into_spec()
-            .expect("market create should parse init args"),
+        } => {
+            let authorization = authorized(&cmd.signer);
+            cmd.try_into_spec(&authorization)
+                .expect("market create should parse init args")
+        }
         _ => panic!("expected Market::Create"),
     };
 
@@ -87,9 +89,11 @@ fn market_create_rejects_missing_init_args_file() {
     let error = match cli.command {
         Command::Market {
             command: MarketNs::Create(cmd),
-        } => cmd
-            .try_into_spec()
-            .expect_err("missing init args file should be rejected"),
+        } => {
+            let authorization = authorized(&cmd.signer);
+            cmd.try_into_spec(&authorization)
+                .expect_err("missing init args file should be rejected")
+        }
         _ => panic!("expected Market::Create"),
     };
 
@@ -124,9 +128,11 @@ fn market_create_rejects_invalid_init_args() {
     let error = match cli.command {
         Command::Market {
             command: MarketNs::Create(cmd),
-        } => cmd
-            .try_into_spec()
-            .expect_err("invalid init args should be rejected"),
+        } => {
+            let authorization = authorized(&cmd.signer);
+            cmd.try_into_spec(&authorization)
+                .expect_err("invalid init args should be rejected")
+        }
         _ => panic!("expected Market::Create"),
     };
 

--- a/tools/manager/src/tests/proxy_oracle.rs
+++ b/tools/manager/src/tests/proxy_oracle.rs
@@ -8,11 +8,11 @@ use near_sdk::Gas;
 
 use templar_gateway_types::ProposalEncoding;
 
-use super::{parse_create_proposal, parse_governance, try_parse_governance, CREDS};
+use super::{authorized, parse_create_proposal, parse_governance, try_parse_governance, CREDS};
 use crate::cli::{Cli, Command};
 use crate::commands::{
     proxy_oracle::{ProxyOracleGovernanceNs, ProxyOracleNs},
-    signer::PrintFormat,
+    signer::{Mode, PrintFormat},
 };
 use templar_common::upgrade::UpgradeSource;
 use templar_common::Nanoseconds;
@@ -108,7 +108,10 @@ fn oracle_create(
     {
         Command::ProxyOracle {
             command: ProxyOracleNs::Create(cmd),
-        } => cmd.try_into_spec(),
+        } => {
+            let authorization = authorized(&cmd.signer);
+            cmd.try_into_spec(&authorization)
+        }
         _ => panic!("expected proxy-oracle create"),
     }
 }
@@ -665,7 +668,10 @@ fn governance_write_commands_accept_print_mode() {
     .expect("immediate execution should support planning") else {
         panic!("expected execute-proposal");
     };
-    assert_eq!(execute.signer.print(), Some(PrintFormat::Sputnik));
+    assert_eq!(
+        authorized(&execute.signer).mode(),
+        &Mode::Plan(PrintFormat::Sputnik)
+    );
 
     let ProxyOracleGovernanceNs::CreateProposal(create) = try_parse_governance([
         "create-proposal",
@@ -687,7 +693,10 @@ fn governance_write_commands_accept_print_mode() {
     .expect("single-write proposal creation should support planning") else {
         panic!("expected create-proposal");
     };
-    assert_eq!(create.signer.print(), Some(PrintFormat::Json));
+    assert_eq!(
+        authorized(&create.signer).mode(),
+        &Mode::Plan(PrintFormat::Json)
+    );
 }
 
 #[test]
@@ -760,7 +769,10 @@ fn governance_create_builds_typed_init_fields() {
         .into_iter()
         .chain(CREDS),
     ) {
-        ProxyOracleGovernanceNs::Create(cmd) => cmd.try_into_spec().expect("into spec"),
+        ProxyOracleGovernanceNs::Create(cmd) => {
+            let authorization = authorized(&cmd.signer);
+            cmd.try_into_spec(&authorization).expect("into spec")
+        }
         _ => panic!("expected governance create"),
     };
 
@@ -1064,9 +1076,9 @@ fn the_upgrade_preflight_is_on_unless_opted_out() {
         "--global-hash",
         "11111111111111111111111111111111",
     ]);
-    assert!(armed.preflight.runs(false));
-    // `--print` builds a payload without submitting, so it stays offline.
-    assert!(!armed.preflight.runs(true));
+    assert!(armed.preflight.runs(&Mode::Keychain));
+    // A plan builds a payload without submitting, so it stays offline.
+    assert!(!armed.preflight.runs(&Mode::Plan(PrintFormat::Json)));
 
     let opted_out = parse_create_proposal([
         "--governance-id",
@@ -1079,5 +1091,5 @@ fn the_upgrade_preflight_is_on_unless_opted_out() {
         "--global-hash",
         "11111111111111111111111111111111",
     ]);
-    assert!(!opted_out.preflight.runs(false));
+    assert!(!opted_out.preflight.runs(&Mode::Keychain));
 }

--- a/tools/manager/src/tests/redstone.rs
+++ b/tools/manager/src/tests/redstone.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 use templar_gateway_methods_spec::redstone as spec;
 
-use super::CREDS;
+use super::{authorized, CREDS};
 use crate::cli::{Cli, Command};
 use crate::commands::RedstoneNs;
 
@@ -128,7 +128,10 @@ fn create(version: &str, source: &[&str]) -> anyhow::Result<spec::Create> {
     match cli.command {
         Command::Redstone {
             command: RedstoneNs::Create(a),
-        } => a.try_into_spec(),
+        } => {
+            let authorization = authorized(&a.signer);
+            a.try_into_spec(&authorization)
+        }
         _ => panic!("expected redstone create"),
     }
 }

--- a/tools/manager/src/tests/registry.rs
+++ b/tools/manager/src/tests/registry.rs
@@ -5,7 +5,7 @@ use near_sdk::json_types::Base58CryptoHash;
 use serde_json::json;
 use templar_common::registry::VersionSource;
 
-use super::{CREDS, TEST_SECRET_KEY};
+use super::{authorized, CREDS, TEST_SECRET_KEY};
 use crate::cli::{Cli, Command};
 use crate::commands::registry::RegistryNs;
 
@@ -493,8 +493,9 @@ fn deploy_plan_uses_explicit_public_key() {
         panic!("expected registry deploy");
     };
 
+    let authorization = authorized(&cmd.signer);
     let spec = cmd
-        .try_into_spec()
+        .try_into_spec(&authorization)
         .expect("explicit public key builds spec");
     let keys = spec.target.full_access_keys.expect("full-access keys");
     assert_eq!(keys.len(), 1);
@@ -531,8 +532,9 @@ fn deploy_plan_without_signer_grant_needs_no_public_key() {
         panic!("expected registry deploy");
     };
 
+    let authorization = authorized(&cmd.signer);
     let spec = cmd
-        .try_into_spec()
+        .try_into_spec(&authorization)
         .expect("suppressed signer grant must not resolve a key");
     assert!(
         spec.target


### PR DESCRIPTION
Closes ENG-712.

`SigningBackend` only named external backends, so the in-process one was selected implicitly by `--secret-key`'s presence: `--help` never listed it and the credential flag doubled as the backend selector — the implicit selection that produced ENG-692.

## Changes

- `SigningBackend::SecretKey` is nameable; `--secret-key` gains `required_if_eq("sign_with", "secret-key")` so naming the default without a key is `MissingRequiredArgument`. `sign_with` stays `Option` (no `default_value_t`, which `required_if_eq` would not evaluate) and is defaulted at the boundary.
- Plan mode and the backend resolve once, from `SignerArgs`, into `Authorization { account_id, asserted_public_key, mode }` with `Mode { Plan(PrintFormat) | InProcess(Box<SecretKey>) | Keychain }`. The ignored-credential warning is emitted from that conversion, once per invocation; `PreflightArgs::runs` takes the mode instead of a bare bool; the four `print().is_some()` sites read the resolved value.
- `public_key()` / `resolve()` move onto `Authorization`. A contradicting `--public-key` is checked at the earliest point each backend allows: the conversion for in-process, `resolve` for the keychain.
- `CliContext::write` → `write_with(signer, into_spec)` → `write_authorized(authorization, body)`; `signing_client_and_key` takes the resolved value. The ~35 plain `ctx.write(a.signer.clone(), spec)` arms are untouched.
- `Mode`'s `Debug` is hand-written: `near_crypto::SecretKey`'s derived `Debug` prints the key.

## CLI

Only one visible change — `secret-key` is now a valid `--sign-with` value. Every previously valid invocation behaves identically.

| invocation | result |
| -- | -- |
| no flags, no key | `MissingRequiredArgument` |
| `--sign-with secret-key`, no key | `MissingRequiredArgument` |
| `--secret-key K` / `$SECRET_KEY`, with or without `--sign-with secret-key` | ok |
| `--print json`, alone or with an ambient `$SECRET_KEY` | ok, one warning |
| `--sign-with keychain` alone | ok |
| `--sign-with …` + `--print` | `ArgumentConflict` |

## Verification

- `just test-fast -p templar-manager`: 401 passed. Every matrix row is a `#[case]` of `write_authorization_matrix`; `help_lists_every_signing_backend`; in-process rstests over `sign_with ∈ {None, Some(SecretKey)}` for `public_key` and offline `resolve`; `Debug` redaction tests.
- `cargo fmt --all --check`, `cargo clippy -p templar-manager --all-features --tests -- -D warnings` clean.
- Built binary spot-checked against the matrix and the early `--public-key` rejection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dfd48nDGufwaCEBQJbZW1u

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/628)
<!-- Reviewable:end -->
