### PR TITLE
fix(common): align market ABI schemas (ENG-696)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12985,6 +12985,7 @@ dependencies = [
  "derive_more 1.0.0",
  "hex",
  "hex-literal",
+ "jsonschema",
  "k256",
  "near-contract-standards",
  "near-jsonrpc-client",

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -29,10 +29,12 @@ clap = { workspace = true, optional = true }
 near-jsonrpc-client = { workspace = true, optional = true }
 near-primitives = { workspace = true, optional = true }
 sha2.workspace = true
+near-sdk = { workspace = true, default-features = false, features = ["abi"] }
 
 [dev-dependencies]
 rstest.workspace = true
 near-sdk = { workspace = true, features = ["unit-testing"] }
+jsonschema = { version = "0.51.0", default-features = false }
 rand = "0.8"
 
 [lints]

--- a/common/src/asset.rs
+++ b/common/src/asset.rs
@@ -411,7 +411,9 @@ impl AssetClass for BorrowAsset {}
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 #[near(serializers = [borsh, json])]
 #[serde(from = "U128", into = "U128")]
+#[cfg_attr(not(target_arch = "wasm32"), schemars(transparent))]
 pub struct FungibleAssetAmount<T: AssetClass> {
+    #[cfg_attr(not(target_arch = "wasm32"), schemars(with = "U128"))]
     amount: U128,
     #[borsh(skip)]
     discriminant: PhantomData<T>,
@@ -595,6 +597,23 @@ mod tests {
         assert_eq!(serialized, "\"100\"");
         let deserialized: BorrowAssetAmount = serde_json::from_str(&serialized).unwrap();
         assert_eq!(deserialized, amount);
+    }
+    #[test]
+    fn amount_schema_matches_serde_wire_format() {
+        let schema = serde_json::to_value(schemars::schema_for!(BorrowAssetAmount))
+            .expect("amount schema serializes");
+        let validator = jsonschema::draft7::new(&schema).expect("amount schema is Draft 7");
+        let amount = BorrowAssetAmount::new(100);
+        let serialized = serde_json::to_value(amount).expect("amount serializes");
+
+        assert_eq!(serialized, serde_json::json!("100"));
+        validator
+            .validate(&serialized)
+            .expect("serialized amount is valid under its schema");
+        assert_eq!(
+            serde_json::from_value::<BorrowAssetAmount>(serialized).expect("amount deserializes"),
+            amount
+        );
     }
 
     #[test]

--- a/common/src/interest_rate_strategy.rs
+++ b/common/src/interest_rate_strategy.rs
@@ -11,7 +11,9 @@ pub trait UsageCurve {
 #[near(serializers = [json, borsh])]
 pub enum InterestRateStrategy {
     Linear(Linear),
+    #[cfg_attr(not(target_arch = "wasm32"), schemars(with = "PiecewiseParams"))]
     Piecewise(Piecewise),
+    #[cfg_attr(not(target_arch = "wasm32"), schemars(with = "Exponential2Params"))]
     Exponential2(Exponential2),
 }
 
@@ -246,6 +248,60 @@ mod tests {
     use std::ops::Div;
 
     use templar_primitives::dec;
+
+    #[test]
+    fn schema_matches_serde_wire_forms() {
+        let schema = near_sdk::serde_json::to_value(schemars::schema_for!(InterestRateStrategy))
+            .expect("strategy schema serializes");
+        let validator = jsonschema::draft7::new(&schema).expect("strategy schema is Draft 7");
+        let strategies = [
+            (
+                InterestRateStrategy::linear(Decimal::ZERO, Decimal::ONE)
+                    .expect("valid linear strategy"),
+                near_sdk::serde_json::json!({"Linear":{"base":"0","top":"1"}}),
+            ),
+            (
+                InterestRateStrategy::piecewise(
+                    Decimal::ZERO,
+                    dec!("0.5"),
+                    dec!("0.125"),
+                    dec!("0.5"),
+                )
+                .expect("valid piecewise strategy"),
+                near_sdk::serde_json::json!({"Piecewise":{"base":"0","optimal":"0.5","rate_1":"0.125","rate_2":"0.5"}}),
+            ),
+            (
+                InterestRateStrategy::exponential2(Decimal::ZERO, Decimal::ONE, Decimal::ONE)
+                    .expect("valid exponential strategy"),
+                near_sdk::serde_json::json!({"Exponential2":{"base":"0","top":"1","eccentricity":"1"}}),
+            ),
+        ];
+
+        for (strategy, expected_json) in strategies {
+            let serialized =
+                near_sdk::serde_json::to_value(&strategy).expect("strategy serialization succeeds");
+            assert_eq!(serialized, expected_json);
+            validator
+                .validate(&serialized)
+                .expect("serialized strategy is valid under its schema");
+            assert_eq!(
+                near_sdk::serde_json::from_value::<InterestRateStrategy>(serialized)
+                    .expect("strategy deserialization succeeds"),
+                strategy
+            );
+        }
+
+        for internal_json in [
+            near_sdk::serde_json::json!({"Piecewise":{"params":{"base":"0","optimal":"0.5","rate_1":"0.125","rate_2":"0.5"},"i_negative_rate_2_b":"0.1875"}}),
+            near_sdk::serde_json::json!({"Exponential2":{"params":{"base":"0","top":"1","eccentricity":"1"},"i_factor":"1"}}),
+        ] {
+            validator
+                .validate(&internal_json)
+                .expect_err("internal runtime representation is not schema-valid");
+            near_sdk::serde_json::from_value::<InterestRateStrategy>(internal_json)
+                .expect_err("internal runtime representation is not serde-valid");
+        }
+    }
 
     use super::*;
 

--- a/common/src/oracle/pyth.rs
+++ b/common/src/oracle/pyth.rs
@@ -27,12 +27,28 @@ pub type OracleResponse = HashMap<PriceIdentifier, Option<Price>>;
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[near(serializers = [borsh, json])]
 pub struct PriceIdentifier(
+    #[cfg_attr(
+        not(target_arch = "wasm32"),
+        schemars(schema_with = "price_identifier_json_schema")
+    )]
     #[serde(
         serialize_with = "hex::serde::serialize",
         deserialize_with = "hex::serde::deserialize"
     )]
     pub [u8; 32],
 );
+
+#[cfg(not(target_arch = "wasm32"))]
+fn price_identifier_json_schema(
+    gen: &mut schemars::gen::SchemaGenerator,
+) -> schemars::schema::Schema {
+    let mut schema = gen.subschema_for::<String>().into_object();
+    let validation = schema.string();
+    validation.min_length = Some(64);
+    validation.max_length = Some(64);
+    validation.pattern = Some("^[0-9A-Fa-f]{64}$".to_string());
+    schema.into()
+}
 
 impl std::fmt::Debug for PriceIdentifier {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -150,6 +166,60 @@ pub trait Pyth {
 mod tests {
     use super::*;
     use templar_primitives::Nanoseconds;
+
+    #[test]
+    fn price_identifier_schema_matches_serde_wire_format() {
+        let schema = near_sdk::serde_json::to_value(schemars::schema_for!(PriceIdentifier))
+            .expect("price identifier schema serializes");
+        let validator =
+            jsonschema::draft7::new(&schema).expect("price identifier schema is Draft 7");
+        let identifier = PriceIdentifier([0xaa; 32]);
+        let serialized =
+            near_sdk::serde_json::to_value(identifier).expect("price identifier serializes");
+
+        assert_eq!(
+            serialized,
+            near_sdk::serde_json::json!(
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            )
+        );
+        validator
+            .validate(&serialized)
+            .expect("serialized price identifier is valid under its schema");
+        assert_eq!(
+            near_sdk::serde_json::from_value::<PriceIdentifier>(serialized)
+                .expect("price identifier deserializes"),
+            identifier
+        );
+
+        let uppercase = near_sdk::serde_json::json!(
+            "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        );
+        validator
+            .validate(&uppercase)
+            .expect("uppercase hexadecimal is schema-valid");
+        assert_eq!(
+            near_sdk::serde_json::from_value::<PriceIdentifier>(uppercase)
+                .expect("uppercase hexadecimal deserializes"),
+            identifier
+        );
+
+        for malformed in [
+            near_sdk::serde_json::json!(
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            ),
+            near_sdk::serde_json::json!(
+                "gaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            ),
+            near_sdk::serde_json::json!([0, 1]),
+        ] {
+            validator
+                .validate(&malformed)
+                .expect_err("malformed price identifier is not schema-valid");
+            near_sdk::serde_json::from_value::<PriceIdentifier>(malformed)
+                .expect_err("malformed price identifier does not deserialize");
+        }
+    }
 
     #[test]
     fn can_parse_real_price() {

--- a/common/src/time_chunk.rs
+++ b/common/src/time_chunk.rs
@@ -17,7 +17,7 @@ pub struct V1 {
 /// Configure a method of determining the current time chunk.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 #[near(serializers = [json, borsh])]
-#[serde(tag = "version")]
+#[cfg_attr(not(target_arch = "wasm32"), schemars(untagged))]
 pub enum TimeChunkConfiguration {
     #[serde(untagged)]
     V0(V0),
@@ -68,6 +68,41 @@ mod tests {
     use super::*;
 
     #[test]
+    fn schema_matches_serde_wire_forms() {
+        let schema = near_sdk::serde_json::to_value(schemars::schema_for!(TimeChunkConfiguration))
+            .expect("time chunk schema serializes");
+        let validator = jsonschema::draft7::new(&schema).expect("time chunk schema is Draft 7");
+        let configurations = [
+            (
+                TimeChunkConfiguration::V0(V0::BlockTimestampMs {
+                    divisor: U64(600_000),
+                }),
+                serde_json::json!({"BlockTimestampMs":{"divisor":"600000"}}),
+            ),
+            (
+                TimeChunkConfiguration::V1(V1 {
+                    duration_ms: U64(600_000),
+                }),
+                serde_json::json!({"duration_ms":"600000"}),
+            ),
+        ];
+
+        for (configuration, expected_json) in configurations {
+            let serialized =
+                serde_json::to_value(&configuration).expect("time chunk serialization succeeds");
+            assert_eq!(serialized, expected_json);
+            validator
+                .validate(&serialized)
+                .expect("serialized time chunk is valid under its schema");
+            assert_eq!(
+                serde_json::from_value::<TimeChunkConfiguration>(serialized)
+                    .expect("time chunk deserialization succeeds"),
+                configuration
+            );
+        }
+    }
+
+    #[test]
     fn now() {
         let context = test_utils::VMContextBuilder::new()
             .block_timestamp((600_000 * 45 + 12345) * 1_000_000 /* ms -> ns */)
@@ -110,6 +145,20 @@ mod tests {
         let s = serde_json::to_string(&v0).unwrap();
 
         assert_eq!(s, r#"{"BlockTimestampMs":{"divisor":"600000"}}"#);
+    }
+
+    #[test]
+    fn v1_deserialization_allows_version_metadata() {
+        let configuration: TimeChunkConfiguration =
+            serde_json::from_str(r#"{"version":"V1","duration_ms":"600000"}"#)
+                .expect("V1 accepts ignored version metadata");
+
+        assert_eq!(
+            configuration,
+            TimeChunkConfiguration::V1(V1 {
+                duration_ms: U64(600_000),
+            })
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Align generated market ABI schemas with existing serde wire forms for interest-rate strategies, time chunks, price identifiers, and fungible asset amounts.
- Add Draft 7 schema/serde conformance regressions.

## Verification
- `just test-fast -p templar-common --lib --features abi`
- `cargo check -p templar-common --lib --features non-contract-usage,abi`
- `cargo check --target wasm32-unknown-unknown -p templar-market-contract`
- `cargo near build non-reproducible-wasm --manifest-path contract/market/Cargo.toml --locked`
- Temporary embedded-ABI probe accepted both shared Piecewise profiles, Exponential2, and Linear; rejected both runtime-only forms.
- `cargo clippy -p templar-common --lib --tests --features non-contract-usage,abi -- -D warnings`
- `cargo fmt --all --check`
- `git diff --check`

The standalone bare `templar-common` Wasm check remains blocked by its existing `getrandom 0.2.17` dependency path; the actual market Wasm build passes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/629)
<!-- Reviewable:end -->
